### PR TITLE
Enhancement: Implement FinalRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 For a full diff see (https://github.com/localheinz/phpstan-rules/compare/0.1.0...HEAD).
 
+### Added
+
+* added `Classes\FinalRule`, which reports an error when a non-anonymous
+  class is not `final`, ([#4](https://github.com/localheinz/phpstan-rules/pull/#4)), by [@localheinz](https://github.com/localheinz)
+
 ## [`0.1.0`](https://github.com/localheinz/phpstan-rules/releases/tag/0.3.0)
 
 For a full diff see [`362c7ea...0.1.0`](https://github.com/localheinz/phpstan-rules/compare/362c7ea...0.1.0).

--- a/README.md
+++ b/README.md
@@ -20,10 +20,15 @@ $ composer require localheinz/phpstan-rules
 This package provides the following rules for use with [`phpstan/phpstan`](https://github.com/phpstan/phpstan):
 
 * [`Localheinz\PHPStan\Rules\Classes\AbstractOrFinalRule`](https://github.com/localheinz/phpstan-rules#classesabstractorfinalrule)
+* [`Localheinz\PHPStan\Rules\Classes\FinalRule`](https://github.com/localheinz/phpstan-rules#classesfinalrule)
 
 ### `Classes\AbstractOrFinalRule`
 
 This rule reports an error when a non-anonymous class is neither `abstract` nor `final`.
+
+### `Classes\FinalRule`
+
+This rule reports an error when a non-anonymous class is not `final`.
 
 ## Usage
 

--- a/src/Classes/FinalRule.php
+++ b/src/Classes/FinalRule.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Classes;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+
+final class FinalRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Stmt\Class_::class;
+    }
+
+    /**
+     * @param Node\Stmt\Class_ $node
+     * @param Scope            $scope
+     *
+     * @return string[] errors
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!isset($node->namespacedName) || $node->isFinal()) {
+            return [];
+        }
+
+        return [
+            \sprintf(
+                'Class "%s" should be marked as final.',
+                $node->namespacedName
+            ),
+        ];
+    }
+}

--- a/test/Integration/Classes/FinalRuleTest.php
+++ b/test/Integration/Classes/FinalRuleTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Integration\Classes;
+
+use Localheinz\PHPStan\Rules\Classes\FinalRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @internal
+ */
+final class FinalRuleTest extends RuleTestCase
+{
+    public function testNotClasses(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/ExampleInterface.php',
+                __DIR__ . '/Fixture/ExampleTrait.php',
+            ],
+            []
+        );
+    }
+
+    public function testFinalClasses(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/FinalClass.php',
+            ],
+            []
+        );
+    }
+
+    public function testConstructsWithAnonymousClasses(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/FinalClassWithAnonymousClass.php',
+                __DIR__ . '/Fixture/script-with-anonymous-class.php',
+                __DIR__ . '/Fixture/TraitWithAnonymousClass.php',
+            ],
+            []
+        );
+    }
+
+    public function testNotFinalClasses(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/Fixture/AbstractClass.php',
+                __DIR__ . '/Fixture/AbstractClassWithAnonymousClass.php',
+                __DIR__ . '/Fixture/NeitherAbstractNorFinalClass.php',
+            ],
+            [
+                [
+                    \sprintf(
+                        'Class "%s" should be marked as final.',
+                        Fixture\AbstractClass::class
+                    ),
+                    16,
+                ],
+                [
+                    \sprintf(
+                        'Class "%s" should be marked as final.',
+                        Fixture\AbstractClassWithAnonymousClass::class
+                    ),
+                    16,
+                ],
+                [
+                    \sprintf(
+                        'Class "%s" should be marked as final.',
+                        Fixture\NeitherAbstractNorFinalClass::class
+                    ),
+                    16,
+                ],
+            ]
+        );
+    }
+
+    protected function getRule(): Rule
+    {
+        return new FinalRule();
+    }
+}

--- a/test/Unit/Classes/FinalRuleTest.php
+++ b/test/Unit/Classes/FinalRuleTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Unit\Classes;
+
+use Localheinz\PHPStan\Rules\Classes\FinalRule;
+use Localheinz\Test\Util\Helper;
+use PhpParser\Node;
+use PHPStan\Analyser;
+use PHPStan\Rules;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @internal
+ */
+final class FinalRuleTest extends RuleTestCase
+{
+    use Helper;
+
+    public function testImplementsRule(): void
+    {
+        $this->assertClassImplementsInterface(Rules\Rule::class, FinalRule::class);
+    }
+
+    public function testGetNodeTypeReturnsClass(): void
+    {
+        $rule = new FinalRule();
+
+        $this->assertSame(Node\Stmt\Class_::class, $rule->getNodeType());
+    }
+
+    public function testProcessNodeReturnsEmptyArrayWhenClassHasNoNamespacedName(): void
+    {
+        $node = $this->prophesize(Node\Stmt\Class_::class);
+
+        $rule = new FinalRule();
+
+        $errors = $rule->processNode(
+            $node->reveal(),
+            $this->prophesize(Analyser\Scope::class)->reveal()
+        );
+
+        $this->assertEmpty($errors);
+    }
+
+    public function testProcessNodeReturnsEmptyArrayWhenClassIsFinal(): void
+    {
+        $node = $this->prophesize(Node\Stmt\Class_::class);
+
+        $node->namespacedName = $this->faker()->word;
+
+        $node
+            ->isFinal()
+            ->shouldBeCalled()
+            ->willReturn(true);
+
+        $rule = new FinalRule();
+
+        $errors = $rule->processNode(
+            $node->reveal(),
+            $this->prophesize(Analyser\Scope::class)->reveal()
+        );
+
+        $this->assertEmpty($errors);
+    }
+
+    public function testProcessNodeReturnsEmptyArrayWhenClassIsNotFinal(): void
+    {
+        $fullyQualifiedClassName = $this->faker()->word;
+
+        $node = $this->prophesize(Node\Stmt\Class_::class);
+
+        $node
+            ->isFinal()
+            ->shouldBeCalled()
+            ->willReturn(false);
+
+        $node->namespacedName = $fullyQualifiedClassName;
+
+        $rule = new FinalRule();
+
+        $errors = $rule->processNode(
+            $node->reveal(),
+            $this->prophesize(Analyser\Scope::class)->reveal()
+        );
+
+        $this->assertCount(1, $errors);
+
+        $error = \array_shift($errors);
+
+        $expected = \sprintf(
+            'Class "%s" should be marked as final.',
+            $fullyQualifiedClassName
+        );
+
+        $this->assertSame($expected, $error);
+    }
+
+    protected function getRule(): Rule
+    {
+        return new FinalRule();
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements a `FinalRule`, which reports an error when a non-anonymous class is not `final`