### PR TITLE
Fix: Remove test asserting that source classes are abstract or final

### DIFF
--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -23,11 +23,6 @@ final class SrcCodeTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testSrcClassesAreAbstractOrFinal(): void
-    {
-        $this->assertClassesAreAbstractOrFinal(__DIR__ . '/../../src');
-    }
-
     public function testSrcClassesHaveUnitTests(): void
     {
         $this->assertClassesHaveTests(


### PR DESCRIPTION
This PR

* [x] removes a test asserting that source classes are `abstract` or `final`

Follows #1.