### PR TITLE
Fix: Suggest to install library as development dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Provides additional rules for [`phpstan/phpstan`](https://github.com/phpstan/php
 Run
 
 ```
-$ composer require localheinz/phpstan-rules
+$ composer require --dev localheinz/phpstan-rules
 ```
 
 ## Rules


### PR DESCRIPTION
This PR

* [x] Describes to default install the lib as dev dependency in the readme.