### PR TITLE
Fix: Test method names

### DIFF
--- a/test/Unit/Classes/AbstractOrFinalRuleTest.php
+++ b/test/Unit/Classes/AbstractOrFinalRuleTest.php
@@ -101,7 +101,7 @@ final class AbstractOrFinalRuleTest extends RuleTestCase
         $this->assertEmpty($errors);
     }
 
-    public function testProcessNodeReturnsEmptyArrayWhenClassIsNeitherAbstractNorFinal(): void
+    public function testProcessNodeReturnsArrayWithErrorWhenClassIsNeitherAbstractNorFinal(): void
     {
         $fullyQualifiedClassName = $this->faker()->word;
 

--- a/test/Unit/Classes/FinalRuleTest.php
+++ b/test/Unit/Classes/FinalRuleTest.php
@@ -75,7 +75,7 @@ final class FinalRuleTest extends RuleTestCase
         $this->assertEmpty($errors);
     }
 
-    public function testProcessNodeReturnsEmptyArrayWhenClassIsNotFinal(): void
+    public function testProcessNodeReturnsArrayWithErrorWhenClassIsNotFinal(): void
     {
         $fullyQualifiedClassName = $this->faker()->word;
 


### PR DESCRIPTION
This PR

* [x] fixes misleading test method names

Follows #1 and #4.