### PR TITLE
Enhancement: Implement NoNullableReturnTypeDeclarationRule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,7 @@ jobs:
         - xdebug-enable
 
       script:
-        - vendor/bin/infection --min-covered-msi=77 --min-msi=77
+        - vendor/bin/infection --min-covered-msi=84 --min-msi=84
 
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 For a full diff see [`0.2.0...master`](https://github.com/localheinz/phpstan-rules/compare/0.2.0...master).
 
+### Added
+
+* added `Functions\NoNullableReturnTypeDeclarationRule`, which reports an
+  error when a named function has a nullable return type declaration, and
+  `Methods\NoNullableReturnTypeDeclarationRule`, which reports an error
+  when a method declared on an anonymous class, a class, or am interface has a
+  nullable return type declaration ([#16](https://github.com/localheinz/phpstan-rules/pull/16)), by [@localheinz](https://github.com/localheinz)
+
 ## [`0.2.0`](https://github.com/localheinz/phpstan-rules/releases/tag/0.2.0)
 
 For a full diff see [`0.1.0...0.2.0`](https://github.com/localheinz/phpstan-rules/compare/0.1.0...0.2.0).

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ cs: vendor
 	vendor/bin/php-cs-fixer fix --config=.php_cs --diff --verbose
 
 infection: vendor
-	vendor/bin/infection --min-covered-msi=77 --min-msi=77
+	vendor/bin/infection --min-covered-msi=84 --min-msi=84
 
 stan: vendor
 	vendor/bin/phpstan analyse --configuration=phpstan.neon --level=max src

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This package provides the following rules for use with [`phpstan/phpstan`](https
 
 * [`Localheinz\PHPStan\Rules\Classes\AbstractOrFinalRule`](https://github.com/localheinz/phpstan-rules#classesabstractorfinalrule)
 * [`Localheinz\PHPStan\Rules\Classes\FinalRule`](https://github.com/localheinz/phpstan-rules#classesfinalrule)
+* [`Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#functionsnonullablereturntypedeclarationrule)
+* [`Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#methodsnonullablereturntypedeclarationrule)
 
 ### `Classes\AbstractOrFinalRule`
 
@@ -70,6 +72,28 @@ services:
 			excludedClassNames:
 				- Bar\Foo
 				- Foo\Bar
+```
+
+### `Functions\NoNullableReturnTypeDeclarationRule`
+
+This rule reports an error when a named function uses a nullable return type declaration.
+
+If you want to use this rule, add it to your `phpstan.neon`:
+
+```neon
+rules:
+	- Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule
+```
+
+### `Methods\NoNullableReturnTypeDeclarationRule`
+
+This rule reports an error when a method declared on an anonymous class, a class, or an interface uses a nullable return type declaration.
+
+If you want to use this rule, add it to your `phpstan.neon`:
+
+```neon
+rules:
+	- Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule
 ```
 
 ## Changelog

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,3 +3,5 @@ includes:
 
 rules:
 	- Localheinz\PHPStan\Rules\Classes\AbstractOrFinalRule
+	- Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule
+	- Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule

--- a/src/Functions/NoNullableReturnTypeDeclarationRule.php
+++ b/src/Functions/NoNullableReturnTypeDeclarationRule.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Functions;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+
+final class NoNullableReturnTypeDeclarationRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Stmt\Function_::class;
+    }
+
+    /**
+     * @param Node\Stmt\Function_ $node
+     * @param Scope               $scope
+     *
+     * @return array
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!isset($node->namespacedName) || !$node->getReturnType() instanceof Node\NullableType) {
+            return [];
+        }
+
+        return [
+            \sprintf(
+                'Function "%s()" should not have a nullable return type declaration.',
+                $node->namespacedName
+            ),
+        ];
+    }
+}

--- a/src/Methods/NoNullableReturnTypeDeclarationRule.php
+++ b/src/Methods/NoNullableReturnTypeDeclarationRule.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Methods;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection;
+use PHPStan\Rules\Rule;
+
+final class NoNullableReturnTypeDeclarationRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Stmt\ClassMethod::class;
+    }
+
+    /**
+     * @param Node\Stmt\ClassMethod $node
+     * @param Scope                 $scope
+     *
+     * @return array
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $returnType = $node->getReturnType();
+
+        if (!$returnType instanceof Node\NullableType) {
+            return [];
+        }
+
+        /** @var Reflection\ClassReflection $classReflection */
+        $classReflection = $scope->getClassReflection();
+
+        if ($classReflection->isAnonymous()) {
+            return [
+                \sprintf(
+                    'Method "%s()" in anonymous class should not have a nullable return type declaration.',
+                    $node->name->name
+                ),
+            ];
+        }
+
+        return [
+            \sprintf(
+                'Method "%s::%s()" should not have a nullable return type declaration.',
+                $classReflection->getName(),
+                $node->name->name
+            ),
+        ];
+    }
+}

--- a/test/Fixture/Functions/NoNullableReturnTypeDeclaration/anonymous-function-in-script-with-nullable-return-type-declaration.php
+++ b/test/Fixture/Functions/NoNullableReturnTypeDeclaration/anonymous-function-in-script-with-nullable-return-type-declaration.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoNullablReturnTypeDeclaration;
+
+$foo = static function (): ?string {
+    return 'Hello';
+};

--- a/test/Fixture/Functions/NoNullableReturnTypeDeclaration/anonymous-function-in-script-with-return-type-declaration.php
+++ b/test/Fixture/Functions/NoNullableReturnTypeDeclaration/anonymous-function-in-script-with-return-type-declaration.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoNullablReturnTypeDeclaration;
+
+$foo = static function (): string {
+    return 'Hello';
+};

--- a/test/Fixture/Functions/NoNullableReturnTypeDeclaration/anonymous-function-in-script-without-return-type-declaration.php
+++ b/test/Fixture/Functions/NoNullableReturnTypeDeclaration/anonymous-function-in-script-without-return-type-declaration.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoNullablReturnTypeDeclaration;
+
+$foo = static function () {
+    return 'Hello';
+};

--- a/test/Fixture/Functions/NoNullableReturnTypeDeclaration/named-function-in-script-with-nullable-return-type-declaration.php
+++ b/test/Fixture/Functions/NoNullableReturnTypeDeclaration/named-function-in-script-with-nullable-return-type-declaration.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoNullablReturnTypeDeclaration;
+
+function foo(): ?string
+{
+    return 'Hello';
+}

--- a/test/Fixture/Functions/NoNullableReturnTypeDeclaration/named-function-in-script-with-return-type-declaration.php
+++ b/test/Fixture/Functions/NoNullableReturnTypeDeclaration/named-function-in-script-with-return-type-declaration.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoNullablReturnTypeDeclaration;
+
+function foo(): string
+{
+    return 'Hello';
+}

--- a/test/Fixture/Functions/NoNullableReturnTypeDeclaration/named-function-in-script-without-return-type-declaration.php
+++ b/test/Fixture/Functions/NoNullableReturnTypeDeclaration/named-function-in-script-without-return-type-declaration.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoNullablReturnTypeDeclaration;
+
+function foo()
+{
+    return 'Hello';
+}

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInAnonymousClassWithNullableReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInAnonymousClassWithNullableReturnTypeDeclaration.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
+
+final class MethodInAnonymousClassWithNullableReturnTypeDeclaration
+{
+    public function foo()
+    {
+        return new class() {
+            public function toString(): ?string
+            {
+                return 'Hello';
+            }
+        };
+    }
+}

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInAnonymousClassWithReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInAnonymousClassWithReturnTypeDeclaration.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
+
+final class MethodInAnonymousClassWithReturnTypeDeclaration
+{
+    public function foo()
+    {
+        return new class() {
+            public function toString(): string
+            {
+                return 'Hello';
+            }
+        };
+    }
+}

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInAnonymousClassWithoutReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInAnonymousClassWithoutReturnTypeDeclaration.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
+
+final class MethodInAnonymousClassWithoutReturnTypeDeclaration
+{
+    public function foo()
+    {
+        return new class() {
+            public function toString()
+            {
+                return 'Hello';
+            }
+        };
+    }
+}

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInClassWithNullableReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInClassWithNullableReturnTypeDeclaration.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
+
+final class MethodInClassWithNullableReturnTypeDeclaration
+{
+    public function toString(): ?string
+    {
+        return 'Hello';
+    }
+}

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInClassWithReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInClassWithReturnTypeDeclaration.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
+
+final class MethodInClassWithReturnTypeDeclaration
+{
+    public function toString(): string
+    {
+        return 'Hello';
+    }
+}

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInClassWithoutReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInClassWithoutReturnTypeDeclaration.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
+
+final class MethodInClassWithoutReturnTypeDeclaration
+{
+    public function toString()
+    {
+        return 'Hello';
+    }
+}

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInInterfaceWithNullableReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInInterfaceWithNullableReturnTypeDeclaration.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
+
+interface MethodInInterfaceWithNullableReturnTypeDeclaration
+{
+    public function toString(): ?string;
+}

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInInterfaceWithReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInInterfaceWithReturnTypeDeclaration.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
+
+interface MethodInInterfaceWithReturnTypeDeclaration
+{
+    public function toString(): string;
+}

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInInterfaceWithoutReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInInterfaceWithoutReturnTypeDeclaration.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
+
+interface MethodInInterfaceWithoutReturnTypeDeclaration
+{
+    public function toString();
+}

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInTraitWithNullableReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInTraitWithNullableReturnTypeDeclaration.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
+
+trait MethodInTraitWithNullableReturnTypeDeclaration
+{
+    public function toString(): ?string
+    {
+        return 'Hello';
+    }
+}

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInTraitWithReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInTraitWithReturnTypeDeclaration.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
+
+trait MethodInTraitWithReturnTypeDeclaration
+{
+    public function toString(): string
+    {
+        return 'Hello';
+    }
+}

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInTraitWithoutReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInTraitWithoutReturnTypeDeclaration.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
+
+trait MethodInTraitWithoutReturnTypeDeclaration
+{
+    public function toString()
+    {
+        return 'Hello';
+    }
+}

--- a/test/Integration/Functions/NoNullableReturnTypeDeclarationRuleTest.php
+++ b/test/Integration/Functions/NoNullableReturnTypeDeclarationRuleTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Integration\Functions;
+
+use Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @internal
+ */
+final class NoNullableReturnTypeDeclarationRuleTest extends RuleTestCase
+{
+    /**
+     * @dataProvider providerAnalysisDoesNotResultInErrors
+     *
+     * @param string $path
+     */
+    public function testAnalysisDoesNotResultInErrors(string $path): void
+    {
+        $this->analyse(
+            [
+                $path,
+            ],
+            []
+        );
+    }
+
+    public function providerAnalysisDoesNotResultInErrors(): \Generator
+    {
+        $paths = [
+            // anonymous functions are not supported, apparently
+            'anonymous-function-in-script-with-nullable-return-type-declaration' => __DIR__ . '/../../Fixture/Functions/NoNullableReturnTypeDeclaration/anonymous-function-in-script-with-nullable-return-type-declaration.php',
+            'anonymous-function-in-script-with-return-type-declaration' => __DIR__ . '/../../Fixture/Functions/NoNullableReturnTypeDeclaration/anonymous-function-in-script-with-return-type-declaration.php',
+            'anonymous-function-in-script-without-return-type-declaration' => __DIR__ . '/../../Fixture/Functions/NoNullableReturnTypeDeclaration/anonymous-function-in-script-without-return-type-declaration.php',
+            'named-function-in-script-with-return-type-declaration' => __DIR__ . '/../../Fixture/Functions/NoNullableReturnTypeDeclaration/named-function-in-script-with-return-type-declaration.php',
+            'named-function-in-script-without-return-type-declaration' => __DIR__ . '/../../Fixture/Functions/NoNullableReturnTypeDeclaration/named-function-in-script-without-return-type-declaration.php',
+        ];
+
+        foreach ($paths as $description => $path) {
+            yield $description => [
+                $path,
+            ];
+        }
+    }
+
+    /**
+     * @dataProvider providerAnalysisResultsInErrors
+     *
+     * @param string $path
+     * @param array  $error
+     */
+    public function testAnalysisResultsInErrors(string $path, array $error): void
+    {
+        $this->analyse(
+            [
+                $path,
+            ],
+            [
+                $error,
+            ]
+        );
+    }
+
+    public function providerAnalysisResultsInErrors(): \Generator
+    {
+        $paths = [
+            'named-function-in-script-with-nullable-return-type-declaration' => [
+                __DIR__ . '/../../Fixture/Functions/NoNullableReturnTypeDeclaration/named-function-in-script-with-nullable-return-type-declaration.php',
+                [
+                    'Function "Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoNullablReturnTypeDeclaration\foo()" should not have a nullable return type declaration.',
+                    16,
+                ],
+            ],
+        ];
+
+        foreach ($paths as $description => [$path, $error]) {
+            yield $description => [
+                $path,
+                $error,
+            ];
+        }
+    }
+
+    protected function getRule(): Rule
+    {
+        return new NoNullableReturnTypeDeclarationRule();
+    }
+}

--- a/test/Integration/Methods/NoNullableReturnTypeDeclarationRuleTest.php
+++ b/test/Integration/Methods/NoNullableReturnTypeDeclarationRuleTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Integration\Methods;
+
+use Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule;
+use Localheinz\PHPStan\Rules\Test\Fixture;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @internal
+ */
+final class NoNullableReturnTypeDeclarationRuleTest extends RuleTestCase
+{
+    /**
+     * @dataProvider providerAnalysisDoesNotResultInErrors
+     *
+     * @param string $path
+     */
+    public function testAnalysisDoesNotResultInErrors(string $path): void
+    {
+        $this->analyse(
+            [
+                $path,
+            ],
+            []
+        );
+    }
+
+    public function providerAnalysisDoesNotResultInErrors(): \Generator
+    {
+        $paths = [
+            'method-in-anonymous-class-with-return-type-declaration' => __DIR__ . '/../../Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInAnonymousClassWithReturnTypeDeclaration.php',
+            'method-in-anonymous-class-without-return-type-declaration' => __DIR__ . '/../../Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInAnonymousClassWithoutReturnTypeDeclaration.php',
+            'method-in-class-with-return-type-declaration' => __DIR__ . '/../../Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInClassWithReturnTypeDeclaration.php',
+            'method-in-class-without-return-type-declaration' => __DIR__ . '/../../Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInClassWithoutReturnTypeDeclaration.php',
+            'method-in-interface-with-return-type-declaration' => __DIR__ . '/../../Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInInterfaceWithReturnTypeDeclaration.php',
+            'method-in-interface-without-return-type-declaration' => __DIR__ . '/../../Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInInterfaceWithoutReturnTypeDeclaration.php',
+            // traits are currently not supported
+            'method-in-trait-with-nullable-return-type-declaration' => __DIR__ . '/../../Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInTraitWithNullableReturnTypeDeclaration.php',
+            'method-in-trait-with-return-type-declaration' => __DIR__ . '/../../Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInTraitWithReturnTypeDeclaration.php',
+            'method-in-trait-without-return-type-declaration' => __DIR__ . '/../../Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInTraitWithoutReturnTypeDeclaration.php',
+        ];
+
+        foreach ($paths as $description => $path) {
+            yield $description => [
+                $path,
+            ];
+        }
+    }
+
+    /**
+     * @dataProvider providerAnalysisResultsInErrors
+     *
+     * @param string $path
+     * @param array  $error
+     */
+    public function testAnalysisResultsInErrors(string $path, array $error): void
+    {
+        $this->analyse(
+            [
+                $path,
+            ],
+            [
+                $error,
+            ]
+        );
+    }
+
+    public function providerAnalysisResultsInErrors(): \Generator
+    {
+        $paths = [
+            'method-in-anonymous-class-with-nullable-return-type-declaration' => [
+                __DIR__ . '/../../Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInAnonymousClassWithNullableReturnTypeDeclaration.php',
+                [
+                    'Method "toString()" in anonymous class should not have a nullable return type declaration.',
+                    21,
+                ],
+            ],
+            'method-in-class-with-nullable-return-type-declaration' => [
+                __DIR__ . '/../../Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInClassWithNullableReturnTypeDeclaration.php',
+                [
+                    \sprintf(
+                        'Method "%s::toString()" should not have a nullable return type declaration.',
+                        Fixture\Methods\NoNullableReturnTypeDeclaration\MethodInClassWithNullableReturnTypeDeclaration::class
+                    ),
+                    18,
+                ],
+            ],
+            'method-in-interface-with-nullable-return-type-declaration' => [
+                __DIR__ . '/../../Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInInterfaceWithNullableReturnTypeDeclaration.php',
+                [
+                    \sprintf(
+                    'Method "%s::toString()" should not have a nullable return type declaration.',
+                    Fixture\Methods\NoNullableReturnTypeDeclaration\MethodInInterfaceWithNullableReturnTypeDeclaration::class
+                    ),
+                    18,
+                ],
+            ],
+        ];
+
+        foreach ($paths as $description => [$path, $error]) {
+            yield $description => [
+                $path,
+                $error,
+            ];
+        }
+    }
+
+    protected function getRule(): Rule
+    {
+        return new NoNullableReturnTypeDeclarationRule();
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements `Functions\NoNullableReturnTypeDeclarationRule`, which reports an error when a function uses a nullable return type, and `Methods\NoNullableReturnTypeDeclarationRule`, which reports an error when a method uses a nullable return type