### PR TITLE
Fix: Add space between parameter type and name

### DIFF
--- a/src/Classes/FinalRule.php
+++ b/src/Classes/FinalRule.php
@@ -40,8 +40,8 @@ final class FinalRule implements Rule
     }
 
     /**
-     * @param Node\Stmt\Class_$node
-     * @param Scope $scope
+     * @param Node\Stmt\Class_ $node
+     * @param Scope            $scope
      *
      * @return array
      */


### PR DESCRIPTION
This PR

* [x] adds a missing space between a parameter type and name

Follows #4.