### PR TITLE
Fix: Use separate php-cs-fixer configuration for fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /.php_cs.cache
+/.php_cs.fixture.cache
 /infection-log.txt

--- a/.php_cs.fixture
+++ b/.php_cs.fixture
@@ -2,7 +2,9 @@
 
 use Localheinz\PhpCsFixer\Config;
 
-$config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71(''));
+$config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71(''), [
+    'static_lambda' => false,
+]);
 
 $config->getFinder()->in(__DIR__ . '/test/Fixture');
 

--- a/.php_cs.fixture
+++ b/.php_cs.fixture
@@ -13,12 +13,10 @@ EOF;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71($header));
 
-$config->getFinder()
-    ->in(__DIR__)
-    ->exclude('test/Fixture');
+$config->getFinder()->in(__DIR__ . '/test/Fixture');
 
 $cacheDir = \getenv('TRAVIS') ? \getenv('HOME') . '/.php-cs-fixer' : __DIR__;
 
-$config->setCacheFile($cacheDir . '/.php_cs.cache');
+$config->setCacheFile($cacheDir . '/.php_cs.fixture.cache');
 
 return $config;

--- a/.php_cs.fixture
+++ b/.php_cs.fixture
@@ -2,16 +2,7 @@
 
 use Localheinz\PhpCsFixer\Config;
 
-$header = <<<EOF
-Copyright (c) 2018 Andreas Möller
-
-For the full copyright and license information, please view
-the LICENSE file that was distributed with this source code.
-
-@see https://github.com/localheinz/phpstan-rules
-EOF;
-
-$config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71($header));
+$config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71(''));
 
 $config->getFinder()->in(__DIR__ . '/test/Fixture');
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ jobs:
       script:
         - composer normalize --dry-run
         - vendor/bin/php-cs-fixer fix --config=.php_cs --diff --dry-run --verbose
+        - vendor/bin/php-cs-fixer fix --config=.php_cs.fixture --diff --dry-run --verbose
 
     - stage: Stan
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ coverage: vendor
 
 cs: vendor
 	vendor/bin/php-cs-fixer fix --config=.php_cs --diff --verbose
+	vendor/bin/php-cs-fixer fix --config=.php_cs.fixture --diff --verbose
 
 infection: vendor
 	vendor/bin/infection --min-covered-msi=84 --min-msi=84

--- a/test/Fixture/Classes/AbstractOrFinalRule/AbstractClass.php
+++ b/test/Fixture/Classes/AbstractOrFinalRule/AbstractClass.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\AbstractOrFinalRule;
 
 abstract class AbstractClass

--- a/test/Fixture/Classes/AbstractOrFinalRule/AbstractClassWithAnonymousClass.php
+++ b/test/Fixture/Classes/AbstractOrFinalRule/AbstractClassWithAnonymousClass.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\AbstractOrFinalRule;
 
 abstract class AbstractClassWithAnonymousClass

--- a/test/Fixture/Classes/AbstractOrFinalRule/ExampleInterface.php
+++ b/test/Fixture/Classes/AbstractOrFinalRule/ExampleInterface.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\AbstractOrFinalRule;
 
 interface ExampleInterface

--- a/test/Fixture/Classes/AbstractOrFinalRule/ExampleTrait.php
+++ b/test/Fixture/Classes/AbstractOrFinalRule/ExampleTrait.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\AbstractOrFinalRule;
 
 trait ExampleTrait

--- a/test/Fixture/Classes/AbstractOrFinalRule/FinalClass.php
+++ b/test/Fixture/Classes/AbstractOrFinalRule/FinalClass.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\AbstractOrFinalRule;
 
 final class FinalClass

--- a/test/Fixture/Classes/AbstractOrFinalRule/FinalClassWithAnonymousClass.php
+++ b/test/Fixture/Classes/AbstractOrFinalRule/FinalClassWithAnonymousClass.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\AbstractOrFinalRule;
 
 final class FinalClassWithAnonymousClass

--- a/test/Fixture/Classes/AbstractOrFinalRule/NeitherAbstractNorFinalClass.php
+++ b/test/Fixture/Classes/AbstractOrFinalRule/NeitherAbstractNorFinalClass.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\AbstractOrFinalRule;
 
 class NeitherAbstractNorFinalClass

--- a/test/Fixture/Classes/AbstractOrFinalRule/NeitherAbstractNorFinalClassButWhitelisted.php
+++ b/test/Fixture/Classes/AbstractOrFinalRule/NeitherAbstractNorFinalClassButWhitelisted.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\AbstractOrFinalRule;
 
 class NeitherAbstractNorFinalClassButWhitelisted

--- a/test/Fixture/Classes/AbstractOrFinalRule/TraitWithAnonymousClass.php
+++ b/test/Fixture/Classes/AbstractOrFinalRule/TraitWithAnonymousClass.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\AbstractOrFinalRule;
 
 trait TraitWithAnonymousClass

--- a/test/Fixture/Classes/AbstractOrFinalRule/script-with-anonymous-class.php
+++ b/test/Fixture/Classes/AbstractOrFinalRule/script-with-anonymous-class.php
@@ -2,14 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
 $foo = new class() {
     public function __toString(): string
     {

--- a/test/Fixture/Classes/FinalRule/AbstractClass.php
+++ b/test/Fixture/Classes/FinalRule/AbstractClass.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule;
 
 abstract class AbstractClass

--- a/test/Fixture/Classes/FinalRule/AbstractClassWithAnonymousClass.php
+++ b/test/Fixture/Classes/FinalRule/AbstractClassWithAnonymousClass.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule;
 
 abstract class AbstractClassWithAnonymousClass

--- a/test/Fixture/Classes/FinalRule/ExampleInterface.php
+++ b/test/Fixture/Classes/FinalRule/ExampleInterface.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule;
 
 interface ExampleInterface

--- a/test/Fixture/Classes/FinalRule/ExampleTrait.php
+++ b/test/Fixture/Classes/FinalRule/ExampleTrait.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule;
 
 trait ExampleTrait

--- a/test/Fixture/Classes/FinalRule/FinalClass.php
+++ b/test/Fixture/Classes/FinalRule/FinalClass.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule;
 
 final class FinalClass

--- a/test/Fixture/Classes/FinalRule/FinalClassWithAnonymousClass.php
+++ b/test/Fixture/Classes/FinalRule/FinalClassWithAnonymousClass.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule;
 
 final class FinalClassWithAnonymousClass

--- a/test/Fixture/Classes/FinalRule/NeitherAbstractNorFinalClass.php
+++ b/test/Fixture/Classes/FinalRule/NeitherAbstractNorFinalClass.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule;
 
 class NeitherAbstractNorFinalClass

--- a/test/Fixture/Classes/FinalRule/NeitherAbstractNorFinalClassButWhitelisted.php
+++ b/test/Fixture/Classes/FinalRule/NeitherAbstractNorFinalClassButWhitelisted.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule;
 
 class NeitherAbstractNorFinalClassButWhitelisted

--- a/test/Fixture/Classes/FinalRule/TraitWithAnonymousClass.php
+++ b/test/Fixture/Classes/FinalRule/TraitWithAnonymousClass.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule;
 
 trait TraitWithAnonymousClass

--- a/test/Fixture/Classes/FinalRule/script-with-anonymous-class.php
+++ b/test/Fixture/Classes/FinalRule/script-with-anonymous-class.php
@@ -2,14 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
 $foo = new class() {
     public function __toString(): string
     {

--- a/test/Fixture/Functions/NoNullableReturnTypeDeclaration/anonymous-function-in-script-with-nullable-return-type-declaration.php
+++ b/test/Fixture/Functions/NoNullableReturnTypeDeclaration/anonymous-function-in-script-with-nullable-return-type-declaration.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoNullablReturnTypeDeclaration;
 
-$foo = static function (): ?string {
+$foo = function (): ?string {
     return 'Hello';
 };

--- a/test/Fixture/Functions/NoNullableReturnTypeDeclaration/anonymous-function-in-script-with-nullable-return-type-declaration.php
+++ b/test/Fixture/Functions/NoNullableReturnTypeDeclaration/anonymous-function-in-script-with-nullable-return-type-declaration.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoNullablReturnTypeDeclaration;
 
 $foo = static function (): ?string {

--- a/test/Fixture/Functions/NoNullableReturnTypeDeclaration/anonymous-function-in-script-with-return-type-declaration.php
+++ b/test/Fixture/Functions/NoNullableReturnTypeDeclaration/anonymous-function-in-script-with-return-type-declaration.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoNullablReturnTypeDeclaration;
 
 $foo = static function (): string {

--- a/test/Fixture/Functions/NoNullableReturnTypeDeclaration/anonymous-function-in-script-with-return-type-declaration.php
+++ b/test/Fixture/Functions/NoNullableReturnTypeDeclaration/anonymous-function-in-script-with-return-type-declaration.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoNullablReturnTypeDeclaration;
 
-$foo = static function (): string {
+$foo = function (): string {
     return 'Hello';
 };

--- a/test/Fixture/Functions/NoNullableReturnTypeDeclaration/anonymous-function-in-script-without-return-type-declaration.php
+++ b/test/Fixture/Functions/NoNullableReturnTypeDeclaration/anonymous-function-in-script-without-return-type-declaration.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoNullablReturnTypeDeclaration;
 
-$foo = static function () {
+$foo = function () {
     return 'Hello';
 };

--- a/test/Fixture/Functions/NoNullableReturnTypeDeclaration/anonymous-function-in-script-without-return-type-declaration.php
+++ b/test/Fixture/Functions/NoNullableReturnTypeDeclaration/anonymous-function-in-script-without-return-type-declaration.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoNullablReturnTypeDeclaration;
 
 $foo = static function () {

--- a/test/Fixture/Functions/NoNullableReturnTypeDeclaration/named-function-in-script-with-nullable-return-type-declaration.php
+++ b/test/Fixture/Functions/NoNullableReturnTypeDeclaration/named-function-in-script-with-nullable-return-type-declaration.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoNullablReturnTypeDeclaration;
 
 function foo(): ?string

--- a/test/Fixture/Functions/NoNullableReturnTypeDeclaration/named-function-in-script-with-return-type-declaration.php
+++ b/test/Fixture/Functions/NoNullableReturnTypeDeclaration/named-function-in-script-with-return-type-declaration.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoNullablReturnTypeDeclaration;
 
 function foo(): string

--- a/test/Fixture/Functions/NoNullableReturnTypeDeclaration/named-function-in-script-without-return-type-declaration.php
+++ b/test/Fixture/Functions/NoNullableReturnTypeDeclaration/named-function-in-script-without-return-type-declaration.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoNullablReturnTypeDeclaration;
 
 function foo()

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInAnonymousClassWithNullableReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInAnonymousClassWithNullableReturnTypeDeclaration.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
 
 final class MethodInAnonymousClassWithNullableReturnTypeDeclaration

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInAnonymousClassWithReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInAnonymousClassWithReturnTypeDeclaration.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
 
 final class MethodInAnonymousClassWithReturnTypeDeclaration

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInAnonymousClassWithoutReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInAnonymousClassWithoutReturnTypeDeclaration.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
 
 final class MethodInAnonymousClassWithoutReturnTypeDeclaration

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInClassWithNullableReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInClassWithNullableReturnTypeDeclaration.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
 
 final class MethodInClassWithNullableReturnTypeDeclaration

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInClassWithReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInClassWithReturnTypeDeclaration.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
 
 final class MethodInClassWithReturnTypeDeclaration

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInClassWithoutReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInClassWithoutReturnTypeDeclaration.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
 
 final class MethodInClassWithoutReturnTypeDeclaration

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInInterfaceWithNullableReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInInterfaceWithNullableReturnTypeDeclaration.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
 
 interface MethodInInterfaceWithNullableReturnTypeDeclaration

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInInterfaceWithReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInInterfaceWithReturnTypeDeclaration.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
 
 interface MethodInInterfaceWithReturnTypeDeclaration

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInInterfaceWithoutReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInInterfaceWithoutReturnTypeDeclaration.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
 
 interface MethodInInterfaceWithoutReturnTypeDeclaration

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInTraitWithNullableReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInTraitWithNullableReturnTypeDeclaration.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
 
 trait MethodInTraitWithNullableReturnTypeDeclaration

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInTraitWithReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInTraitWithReturnTypeDeclaration.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
 
 trait MethodInTraitWithReturnTypeDeclaration

--- a/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInTraitWithoutReturnTypeDeclaration.php
+++ b/test/Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInTraitWithoutReturnTypeDeclaration.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/**
- * Copyright (c) 2018 Andreas Möller.
- *
- * For the full copyright and license information, please view
- * the LICENSE file that was distributed with this source code.
- *
- * @see https://github.com/localheinz/phpstan-rules
- */
-
 namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoNullableReturnTypeDeclaration;
 
 trait MethodInTraitWithoutReturnTypeDeclaration

--- a/test/Integration/Classes/AbstractOrFinalRuleTest.php
+++ b/test/Integration/Classes/AbstractOrFinalRuleTest.php
@@ -87,7 +87,7 @@ final class AbstractOrFinalRuleTest extends RuleTestCase
                         'Class "%s" should be marked as abstract or final.',
                         Fixture\Classes\AbstractOrFinalRule\NeitherAbstractNorFinalClass::class
                     ),
-                    16,
+                    7,
                 ],
             ],
         ];

--- a/test/Integration/Classes/FinalRuleTest.php
+++ b/test/Integration/Classes/FinalRuleTest.php
@@ -85,7 +85,7 @@ final class FinalRuleTest extends RuleTestCase
                         'Class "%s" should be marked as final.',
                         Fixture\Classes\FinalRule\NeitherAbstractNorFinalClass::class
                     ),
-                    16,
+                    7,
                 ],
             ],
             'abstract-class-with-anonymous-class' => [
@@ -95,7 +95,7 @@ final class FinalRuleTest extends RuleTestCase
                         'Class "%s" should be marked as final.',
                         Fixture\Classes\FinalRule\AbstractClassWithAnonymousClass::class
                     ),
-                    16,
+                    7,
                 ],
             ],
             'neither-abstract-nor-final-class' => [
@@ -105,7 +105,7 @@ final class FinalRuleTest extends RuleTestCase
                         'Class "%s" should be marked as final.',
                         Fixture\Classes\FinalRule\NeitherAbstractNorFinalClass::class
                     ),
-                    16,
+                    7,
                 ],
             ],
         ];

--- a/test/Integration/Functions/NoNullableReturnTypeDeclarationRuleTest.php
+++ b/test/Integration/Functions/NoNullableReturnTypeDeclarationRuleTest.php
@@ -80,7 +80,7 @@ final class NoNullableReturnTypeDeclarationRuleTest extends RuleTestCase
                 __DIR__ . '/../../Fixture/Functions/NoNullableReturnTypeDeclaration/named-function-in-script-with-nullable-return-type-declaration.php',
                 [
                     'Function "Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoNullablReturnTypeDeclaration\foo()" should not have a nullable return type declaration.',
-                    16,
+                    7,
                 ],
             ],
         ];

--- a/test/Integration/Methods/NoNullableReturnTypeDeclarationRuleTest.php
+++ b/test/Integration/Methods/NoNullableReturnTypeDeclarationRuleTest.php
@@ -85,7 +85,7 @@ final class NoNullableReturnTypeDeclarationRuleTest extends RuleTestCase
                 __DIR__ . '/../../Fixture/Methods/NoNullableReturnTypeDeclaration/MethodInAnonymousClassWithNullableReturnTypeDeclaration.php',
                 [
                     'Method "toString()" in anonymous class should not have a nullable return type declaration.',
-                    21,
+                    12,
                 ],
             ],
             'method-in-class-with-nullable-return-type-declaration' => [
@@ -95,7 +95,7 @@ final class NoNullableReturnTypeDeclarationRuleTest extends RuleTestCase
                         'Method "%s::toString()" should not have a nullable return type declaration.',
                         Fixture\Methods\NoNullableReturnTypeDeclaration\MethodInClassWithNullableReturnTypeDeclaration::class
                     ),
-                    18,
+                    9,
                 ],
             ],
             'method-in-interface-with-nullable-return-type-declaration' => [
@@ -105,7 +105,7 @@ final class NoNullableReturnTypeDeclarationRuleTest extends RuleTestCase
                     'Method "%s::toString()" should not have a nullable return type declaration.',
                     Fixture\Methods\NoNullableReturnTypeDeclaration\MethodInInterfaceWithNullableReturnTypeDeclaration::class
                     ),
-                    18,
+                    9,
                 ],
             ],
         ];


### PR DESCRIPTION
This PR

* [x] uses a separate `php-cs-fixer` configuration for fixtures
* [x] disables headers for fixtures
* [x] disables the `static_lambda` fixer for fixtures