### PR TITLE
Enhancement: Implement Closures\NoParameterWithNullDefaultValueRule

### DIFF
--- a/.php_cs.fixture
+++ b/.php_cs.fixture
@@ -3,6 +3,7 @@
 use Localheinz\PhpCsFixer\Config;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71(''), [
+    'lowercase_constants' => false,
     'static_lambda' => false,
 ]);
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -129,7 +129,7 @@ jobs:
         - xdebug-enable
 
       script:
-        - vendor/bin/infection --min-covered-msi=85 --min-msi=85
+        - vendor/bin/infection --min-covered-msi=90 --min-msi=90
 
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ For a full diff see [`0.2.0...master`](https://github.com/localheinz/phpstan-rul
   `Methods\NoNullableReturnTypeDeclarationRule`, which reports an error
   when a method declared on an anonymous class, a class, or an interface has a
   nullable return type declaration ([#16](https://github.com/localheinz/phpstan-rules/pull/16)), by [@localheinz](https://github.com/localheinz)
+* added `Closures\NoParameterWithNullDefaultValueRule`, which reports an
+  error when a closure has a parameter with `null` as default value ([#26](https://github.com/localheinz/phpstan-rules/pull/26)), by [@localheinz](https://github.com/localheinz)
 * added `Closures\NoNullableReturnTypeDeclarationRule`, which reports an
   error when a closure has a nullable return type declaration ([#29](https://github.com/localheinz/phpstan-rules/pull/29)), by [@localheinz](https://github.com/localheinz)
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ cs: vendor
 	vendor/bin/php-cs-fixer fix --config=.php_cs.fixture --diff --verbose
 
 infection: vendor
-	vendor/bin/infection --min-covered-msi=85 --min-msi=85
+	vendor/bin/infection --min-covered-msi=90 --min-msi=90
 
 stan: vendor
 	vendor/bin/phpstan analyse --configuration=phpstan.neon --level=max src

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This package provides the following rules for use with [`phpstan/phpstan`](https
 * [`Localheinz\PHPStan\Rules\Classes\AbstractOrFinalRule`](https://github.com/localheinz/phpstan-rules#classesabstractorfinalrule)
 * [`Localheinz\PHPStan\Rules\Classes\FinalRule`](https://github.com/localheinz/phpstan-rules#classesfinalrule)
 * [`Localheinz\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#closuresnonullablereturntypedeclarationrule)
+* [`Localheinz\PHPStan\Rules\Closures\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#closuresnoparameterwithnulldefaultvaluerule)
 * [`Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#functionsnonullablereturntypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#methodsnonullablereturntypedeclarationrule)
 
@@ -84,6 +85,17 @@ If you want to use this rule, add it to your `phpstan.neon`:
 ```neon
 rules:
 	- Localheinz\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule
+```
+
+### `Closures\NoParameterWithNullDefaultValueRule`
+
+This rule reports an error when a closure has a parameter with `null` as default value.
+
+If you want to use this rule, add it to your `phpstan.neon`:
+
+```neon
+rules:
+	- Localheinz\PHPStan\Rules\Closures\NoParameterWithNullDefaultValueRule
 ```
 
 ### `Functions\NoNullableReturnTypeDeclarationRule`

--- a/src/Closures/NoParameterWithNullDefaultValueRule.php
+++ b/src/Closures/NoParameterWithNullDefaultValueRule.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Closures;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+
+final class NoParameterWithNullDefaultValueRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Expr\Closure::class;
+    }
+
+    /**
+     * @param Node\Expr\Closure $node
+     * @param Scope             $scope
+     *
+     * @return array
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (0 === \count($node->params)) {
+            return [];
+        }
+
+        $params = \array_filter($node->params, static function (Node\Param $node): bool {
+            if (!$node->default instanceof Node\Expr\ConstFetch) {
+                return false;
+            }
+
+            return 'null' === $node->default->name->toLowerString();
+        });
+
+        if (0 === \count($params)) {
+            return [];
+        }
+
+        return \array_map(static function (Node\Param $node): string {
+            /** @var Node\Expr\Variable $variable */
+            $variable = $node->var;
+
+            /** @var string $parameterName */
+            $parameterName = $variable->name;
+
+            return \sprintf(
+                'Parameter "$%s" of closure should not have null as default value.',
+                $parameterName
+            );
+        }, $params);
+    }
+}

--- a/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Failure/closure-with-parameter-with-null-default-value.php
+++ b/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Failure/closure-with-parameter-with-null-default-value.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
+
+$foo = function ($bar = null) {
+    return $bar;
+};

--- a/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Failure/closure-with-parameter-with-root-namespace-referenced-null-default-value.php
+++ b/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Failure/closure-with-parameter-with-root-namespace-referenced-null-default-value.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
+
+$foo = function ($bar = null) {
+    return $bar;
+};

--- a/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Failure/closure-with-parameter-with-wrongly-capitalized-null-default-value.php
+++ b/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Failure/closure-with-parameter-with-wrongly-capitalized-null-default-value.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
+
+$foo = function ($bar = null) {
+    return $bar;
+};

--- a/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Success/closure-with-parameter-with-non-null-default-value.php
+++ b/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Success/closure-with-parameter-with-non-null-default-value.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
+
+$foo = function ($bar = true) {
+    return $bar;
+};

--- a/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Success/closure-with-parameter-without-default-value.php
+++ b/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Success/closure-with-parameter-without-default-value.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
+
+$foo = function ($bar) {
+    return $bar;
+};

--- a/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Success/closure-without-parameters.php
+++ b/test/Fixture/Closures/NoParameterWithNullDefaultValueRule/Success/closure-without-parameters.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Closures\NoParameterWithNullDefaultValueRule\Success;
+
+$foo = function () {
+};

--- a/test/Integration/Closures/NoParameterWithNullDefaultValueRuleTest.php
+++ b/test/Integration/Closures/NoParameterWithNullDefaultValueRuleTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Integration\Closures;
+
+use Localheinz\PHPStan\Rules\Closures\NoParameterWithNullDefaultValueRule;
+use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use PHPStan\Rules\Rule;
+
+/**
+ * @internal
+ */
+final class NoParameterWithNullDefaultValueRuleTest extends AbstractTestCase
+{
+    public function providerAnalysisSucceeds(): \Generator
+    {
+        $paths = [
+            'closure-with-parameter-with-non-null-default-value' => __DIR__ . '/../../Fixture/Closures/NoParameterWithNullDefaultValueRule/Success/closure-with-parameter-with-non-null-default-value.php',
+            'closure-with-parameter-without-default-value' => __DIR__ . '/../../Fixture/Closures/NoParameterWithNullDefaultValueRule/Success/closure-with-parameter-without-default-value.php',
+            'closure-with-parameter-without-parameters' => __DIR__ . '/../../Fixture/Closures/NoParameterWithNullDefaultValueRule/Success/closure-without-parameters.php',
+        ];
+
+        foreach ($paths as $description => $path) {
+            yield $description => [
+                $path,
+            ];
+        }
+    }
+
+    public function providerAnalysisFails(): \Generator
+    {
+        $paths = [
+            'closure-with-parameter-with-null-default-value' => [
+                __DIR__ . '/../../Fixture/Closures/NoParameterWithNullDefaultValueRule/Failure/closure-with-parameter-with-null-default-value.php',
+                [
+                    'Parameter "$bar" of closure should not have null as default value.',
+                    7,
+                ],
+            ],
+            'closure-with-parameter-with-root-namespace-referenced-null-default-value' => [
+                __DIR__ . '/../../Fixture/Closures/NoParameterWithNullDefaultValueRule/Failure/closure-with-parameter-with-root-namespace-referenced-null-default-value.php',
+                [
+                    'Parameter "$bar" of closure should not have null as default value.',
+                    7,
+                ],
+            ],
+            'closure-with-parameter-with-wrongly-capitalized-null-default-value' => [
+                __DIR__ . '/../../Fixture/Closures/NoParameterWithNullDefaultValueRule/Failure/closure-with-parameter-with-wrongly-capitalized-null-default-value.php',
+                [
+                    'Parameter "$bar" of closure should not have null as default value.',
+                    7,
+                ],
+            ],
+        ];
+
+        foreach ($paths as $description => [$path, $error]) {
+            yield $description => [
+                $path,
+                $error,
+            ];
+        }
+    }
+
+    protected function getRule(): Rule
+    {
+        return new NoParameterWithNullDefaultValueRule();
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements `Closures\NoParameterWithNullDefaultValueRule`, which reports an error when a closure has a parameter with `null` as default value