### PR TITLE
Enhancement: Implement Functions\NoParameterWithNullDefaultValueRule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,7 +129,7 @@ jobs:
         - xdebug-enable
 
       script:
-        - vendor/bin/infection --min-covered-msi=90 --min-msi=90
+        - vendor/bin/infection --min-covered-msi=92 --min-msi=92
 
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ For a full diff see [`0.2.0...master`](https://github.com/localheinz/phpstan-rul
   error when a closure has a parameter with `null` as default value ([#26](https://github.com/localheinz/phpstan-rules/pull/26)), by [@localheinz](https://github.com/localheinz)
 * added `Closures\NoNullableReturnTypeDeclarationRule`, which reports an
   error when a closure has a nullable return type declaration ([#29](https://github.com/localheinz/phpstan-rules/pull/29)), by [@localheinz](https://github.com/localheinz)
+* added `Functions\NoParameterWithNullDefaultValueRule`, which reports an
+  error when a function has a parameter with `null` as default value ([#31](https://github.com/localheinz/phpstan-rules/pull/31)), by [@localheinz](https://github.com/localheinz)
 
 ## [`0.2.0`](https://github.com/localheinz/phpstan-rules/releases/tag/0.2.0)
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ cs: vendor
 	vendor/bin/php-cs-fixer fix --config=.php_cs.fixture --diff --verbose
 
 infection: vendor
-	vendor/bin/infection --min-covered-msi=90 --min-msi=90
+	vendor/bin/infection --min-covered-msi=92 --min-msi=92
 
 stan: vendor
 	vendor/bin/phpstan analyse --configuration=phpstan.neon --level=max src

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This package provides the following rules for use with [`phpstan/phpstan`](https
 * [`Localheinz\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#closuresnonullablereturntypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Closures\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#closuresnoparameterwithnulldefaultvaluerule)
 * [`Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#functionsnonullablereturntypedeclarationrule)
+* [`Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#functionsnoparameterwithnulldefaultvaluerule)
 * [`Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#methodsnonullablereturntypedeclarationrule)
 
 ### `Classes\AbstractOrFinalRule`
@@ -107,6 +108,17 @@ If you want to use this rule, add it to your `phpstan.neon`:
 ```neon
 rules:
 	- Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule
+```
+
+### `Functions\NoParameterWithNullDefaultValueRule`
+
+This rule reports an error when a function has a parameter with `null` as default value.
+
+If you want to use this rule, add it to your `phpstan.neon`:
+
+```neon
+rules:
+	- Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule
 ```
 
 ### `Methods\NoNullableReturnTypeDeclarationRule`

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,4 +5,5 @@ rules:
 	- Localheinz\PHPStan\Rules\Classes\AbstractOrFinalRule
 	- Localheinz\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule
+	- Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule
 	- Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule

--- a/src/Functions/NoParameterWithNullDefaultValueRule.php
+++ b/src/Functions/NoParameterWithNullDefaultValueRule.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Functions;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+
+final class NoParameterWithNullDefaultValueRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Stmt\Function_::class;
+    }
+
+    /**
+     * @param Node\Stmt\Function_ $node
+     * @param Scope               $scope
+     *
+     * @return array
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (0 === \count($node->params)) {
+            return [];
+        }
+
+        $params = \array_filter($node->params, static function (Node\Param $node): bool {
+            if (!$node->default instanceof Node\Expr\ConstFetch) {
+                return false;
+            }
+
+            return 'null' === $node->default->name->toLowerString();
+        });
+
+        if (0 === \count($params)) {
+            return [];
+        }
+
+        $functionName = $node->namespacedName;
+
+        return \array_map(static function (Node\Param $node) use ($functionName): string {
+            /** @var Node\Expr\Variable $variable */
+            $variable = $node->var;
+
+            /** @var string $parameterName */
+            $parameterName = $variable->name;
+
+            return \sprintf(
+                'Parameter "$%s" of function "%s()" should not have null as default value.',
+                $parameterName,
+                $functionName
+            );
+        }, $params);
+    }
+}

--- a/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Failure/function-with-parameter-with-null-default-value.php
+++ b/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Failure/function-with-parameter-with-null-default-value.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Failure;
+
+function foo($bar = null)
+{
+    return $bar;
+}

--- a/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Failure/function-with-parameter-with-root-namespace-referenced-null-default-value.php
+++ b/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Failure/function-with-parameter-with-root-namespace-referenced-null-default-value.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Failure;
+
+function foo($bar = \null)
+{
+    return $bar;
+}

--- a/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Failure/function-with-parameter-with-wrongly-capitalized-null-default-value.php
+++ b/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Failure/function-with-parameter-with-wrongly-capitalized-null-default-value.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Failure;
+
+function foo($bar = nUlL)
+{
+    return $bar;
+}

--- a/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Success/function-with-parameter-with-non-null-default-value.php
+++ b/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Success/function-with-parameter-with-non-null-default-value.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Success;
+
+function foo($bar = true)
+{
+    return $bar;
+}

--- a/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Success/function-with-parameter-without-default-value.php
+++ b/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Success/function-with-parameter-without-default-value.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Success;
+
+function foo($bar)
+{
+    return $bar;
+}

--- a/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Success/function-without-parameters.php
+++ b/test/Fixture/Functions/NoParameterWithNullDefaultValueRule/Success/function-without-parameters.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Success;
+
+function foo()
+{
+}

--- a/test/Integration/Functions/NoParameterWithNullDefaultValueRuleTest.php
+++ b/test/Integration/Functions/NoParameterWithNullDefaultValueRuleTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Integration\Functions;
+
+use Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule;
+use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use PHPStan\Rules\Rule;
+
+/**
+ * @internal
+ */
+final class NoParameterWithNullDefaultValueRuleTest extends AbstractTestCase
+{
+    public function providerAnalysisSucceeds(): \Generator
+    {
+        $paths = [
+            'function-with-parameter-with-non-null-default-value' => __DIR__ . '/../../Fixture/Functions/NoParameterWithNullDefaultValueRule/Success/function-with-parameter-with-non-null-default-value.php',
+            'function-with-parameter-without-default-value' => __DIR__ . '/../../Fixture/Functions/NoParameterWithNullDefaultValueRule/Success/function-with-parameter-without-default-value.php',
+            'function-without-parameters' => __DIR__ . '/../../Fixture/Functions/NoParameterWithNullDefaultValueRule/Success/function-without-parameters.php',
+        ];
+
+        foreach ($paths as $description => $path) {
+            yield $description => [
+                $path,
+            ];
+        }
+    }
+
+    public function providerAnalysisFails(): \Generator
+    {
+        $paths = [
+            'function-with-parameter-with-null-default-value' => [
+                __DIR__ . '/../../Fixture/Functions/NoParameterWithNullDefaultValueRule/Failure/function-with-parameter-with-null-default-value.php',
+                [
+                    'Parameter "$bar" of function "Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Failure\foo()" should not have null as default value.',
+                    7,
+                ],
+            ],
+            'function-with-parameter-with-root-namespace-referenced-null-default-value' => [
+                __DIR__ . '/../../Fixture/Functions/NoParameterWithNullDefaultValueRule/Failure/function-with-parameter-with-root-namespace-referenced-null-default-value.php',
+                [
+                    'Parameter "$bar" of function "Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Failure\foo()" should not have null as default value.',
+                    7,
+                ],
+            ],
+            'function-with-parameter-with-wrongly-capitalized-null-default-value' => [
+                __DIR__ . '/../../Fixture/Functions/NoParameterWithNullDefaultValueRule/Failure/function-with-parameter-with-wrongly-capitalized-null-default-value.php',
+                [
+                    'Parameter "$bar" of function "Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullDefaultValueRule\Failure\foo()" should not have null as default value.',
+                    7,
+                ],
+            ],
+        ];
+
+        foreach ($paths as $description => [$path, $error]) {
+            yield $description => [
+                $path,
+                $error,
+            ];
+        }
+    }
+
+    protected function getRule(): Rule
+    {
+        return new NoParameterWithNullDefaultValueRule();
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements `Functions\NoParameterWithNullDefaultValueRule`, which reports an error when a function has a parameter with `null` as default value