### PR TITLE
Enhancement: Implement Methods\NoParameterWithNullDefaultValueRule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,7 +129,7 @@ jobs:
         - xdebug-enable
 
       script:
-        - vendor/bin/infection --min-covered-msi=92 --min-msi=92
+        - vendor/bin/infection --min-covered-msi=94 --min-msi=94
 
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ For a full diff see [`0.2.0...master`](https://github.com/localheinz/phpstan-rul
   error when a closure has a nullable return type declaration ([#29](https://github.com/localheinz/phpstan-rules/pull/29)), by [@localheinz](https://github.com/localheinz)
 * added `Functions\NoParameterWithNullDefaultValueRule`, which reports an
   error when a function has a parameter with `null` as default value ([#31](https://github.com/localheinz/phpstan-rules/pull/31)), by [@localheinz](https://github.com/localheinz)
+* added `Methods\NoParameterWithNullDefaultValueRule`, which reports an
+  error when a method declared on an anonymous class, a class, or an interface
+  has a parameter with `null` as default value ([#32](https://github.com/localheinz/phpstan-rules/pull/32)), by [@localheinz](https://github.com/localheinz)
 
 ## [`0.2.0`](https://github.com/localheinz/phpstan-rules/releases/tag/0.2.0)
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ cs: vendor
 	vendor/bin/php-cs-fixer fix --config=.php_cs.fixture --diff --verbose
 
 infection: vendor
-	vendor/bin/infection --min-covered-msi=92 --min-msi=92
+	vendor/bin/infection --min-covered-msi=94 --min-msi=94
 
 stan: vendor
 	vendor/bin/phpstan analyse --configuration=phpstan.neon --level=max src

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This package provides the following rules for use with [`phpstan/phpstan`](https
 * [`Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#functionsnonullablereturntypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#functionsnoparameterwithnulldefaultvaluerule)
 * [`Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#methodsnonullablereturntypedeclarationrule)
+* [`Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#methodsnoparameterwithnulldefaultvaluerule)
 
 ### `Classes\AbstractOrFinalRule`
 
@@ -130,6 +131,17 @@ If you want to use this rule, add it to your `phpstan.neon`:
 ```neon
 rules:
 	- Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule
+```
+
+### `Methods\NoParameterWithNullDefaultValueRule`
+
+This rule reports an error when a method declared in an anonymous class, a class, or an interface has a parameter with `null` as default value.
+
+If you want to use this rule, add it to your `phpstan.neon`:
+
+```neon
+rules:
+	- Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule
 ```
 
 ## Changelog

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,4 @@ rules:
 	- Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule
 	- Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule
+	- Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule

--- a/src/Methods/NoParameterWithNullDefaultValueRule.php
+++ b/src/Methods/NoParameterWithNullDefaultValueRule.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Methods;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection;
+use PHPStan\Rules\Rule;
+
+final class NoParameterWithNullDefaultValueRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Stmt\ClassMethod::class;
+    }
+
+    /**
+     * @param Node\Stmt\ClassMethod $node
+     * @param Scope                 $scope
+     *
+     * @return array
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (0 === \count($node->params)) {
+            return [];
+        }
+
+        $params = \array_filter($node->params, static function (Node\Param $node): bool {
+            if (!$node->default instanceof Node\Expr\ConstFetch) {
+                return false;
+            }
+
+            return 'null' === $node->default->name->toLowerString();
+        });
+
+        if (0 === \count($params)) {
+            return [];
+        }
+
+        $methodName = $node->name->toString();
+
+        /** @var Reflection\ClassReflection $classReflection */
+        $classReflection = $scope->getClassReflection();
+
+        if ($classReflection->isAnonymous()) {
+            return \array_map(static function (Node\Param $node) use ($methodName): string {
+                /** @var Node\Expr\Variable $variable */
+                $variable = $node->var;
+
+                /** @var string $parameterName */
+                $parameterName = $variable->name;
+
+                return \sprintf(
+                    'Parameter "$%s" of method "%s()" in anonymous class should not have null as default value.',
+                    $parameterName,
+                    $methodName
+                );
+            }, $params);
+        }
+
+        $className = $classReflection->getName();
+
+        return \array_map(static function (Node\Param $node) use ($className, $methodName): string {
+            /** @var Node\Expr\Variable $variable */
+            $variable = $node->var;
+
+            /** @var string $parameterName */
+            $parameterName = $variable->name;
+
+            return \sprintf(
+                'Parameter "$%s" of method "%s::%s()" should not have null as default value.',
+                $parameterName,
+                $className,
+                $methodName
+            );
+        }, $params);
+    }
+}

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInClassWithParameterWithNullDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInClassWithParameterWithNullDefaultValue.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure;
+
+final class MethodInClassWithParameterWithNullDefaultValue
+{
+    public function foo($bar = null)
+    {
+        return $bar;
+    }
+}

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInClassWithParameterWithRootNamespaceReferencedNullDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInClassWithParameterWithRootNamespaceReferencedNullDefaultValue.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure;
+
+final class MethodInClassWithParameterWithRootNamespaceReferencedNullDefaultValue
+{
+    public function foo($bar = \null)
+    {
+        return $bar;
+    }
+}

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInClassWithParameterWithWronglyCapitalizedNullDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInClassWithParameterWithWronglyCapitalizedNullDefaultValue.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure;
+
+final class MethodInClassWithParameterWithWronglyCapitalizedNullDefaultValue
+{
+    public function foo($bar = NuLl)
+    {
+        return $bar;
+    }
+}

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInInterfaceWithParameterWithNullDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInInterfaceWithParameterWithNullDefaultValue.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure;
+
+interface MethodInInterfaceWithParameterWithNullDefaultValue
+{
+    public function foo($bar = null);
+}

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInInterfaceWithParameterWithRootNamespaceReferencedNullDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInInterfaceWithParameterWithRootNamespaceReferencedNullDefaultValue.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure;
+
+interface MethodInInterfaceWithParameterWithRootNamespaceReferencedNullDefaultValue
+{
+    public function foo($bar = \null);
+}

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInInterfaceWithParameterWithWronlgyCapitalizedNullDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInInterfaceWithParameterWithWronlgyCapitalizedNullDefaultValue.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure;
+
+interface MethodInInterfaceWithParameterWithWronlgyCapitalizedNullDefaultValue
+{
+    public function foo($bar = NuLl);
+}

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/method-in-anonymous-class-with-parameter-with-null-default-value.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/method-in-anonymous-class-with-parameter-with-null-default-value.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+
+new class() {
+    public function foo($bar = null)
+    {
+        return $bar;
+    }
+};

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/method-in-anonymous-class-with-parameter-with-root-namespace-referenced-null-default-value.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/method-in-anonymous-class-with-parameter-with-root-namespace-referenced-null-default-value.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+
+new class() {
+    public function foo($bar = \null)
+    {
+        return $bar;
+    }
+};

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/method-in-anonymous-class-with-parameter-with-wrongly-capitalized-null-default-value.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/method-in-anonymous-class-with-parameter-with-wrongly-capitalized-null-default-value.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+
+new class() {
+    public function foo($bar = NuLl)
+    {
+        return $bar;
+    }
+};

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInClassWithParameterWithNonNullDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInClassWithParameterWithNonNullDefaultValue.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+
+final class MethodInClassWithParameterWithNonNullDefaultValue
+{
+    public function foo($bar = true)
+    {
+        return $bar;
+    }
+}

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInClassWithParameterWithoutDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInClassWithParameterWithoutDefaultValue.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+
+final class MethodInClassWithParameterWithoutDefaultValue
+{
+    public function foo($bar)
+    {
+        return $bar;
+    }
+}

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInClassWithoutParameters.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInClassWithoutParameters.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+
+final class MethodInClassWithoutParameters
+{
+    public function foo()
+    {
+    }
+}

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInInterfaceWithParameterWithNonNullDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInInterfaceWithParameterWithNonNullDefaultValue.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+
+interface MethodInInterfaceWithParameterWithNonNullDefaultValue
+{
+    public function foo($bar = true);
+}

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInInterfaceWithParameterWithoutDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInInterfaceWithParameterWithoutDefaultValue.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+
+interface MethodInInterfaceWithParameterWithoutDefaultValue
+{
+    public function foo($bar);
+}

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInInterfaceWithoutParameters.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInInterfaceWithoutParameters.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+
+interface MethodInInterfaceWithoutParameters
+{
+    public function foo();
+}

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithDefaultValue.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+
+trait MethodInTraitWithParameterWithDefaultValue
+{
+    public function foo($bar = 'null')
+    {
+        return $bar;
+    }
+}

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithNonNullDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithNonNullDefaultValue.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+
+trait MethodInTraitWithParameterWithNonNullDefaultValue
+{
+    public function foo($bar = true)
+    {
+        return $bar;
+    }
+}

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithRootNamespaceReferencedNullDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithRootNamespaceReferencedNullDefaultValue.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+
+trait MethodInTraitWithParameterWithRootNamespaceReferencedNullDefaultValue
+{
+    public function foo($bar = \null)
+    {
+        return $bar;
+    }
+}

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithWronlgyCapitalizedNullDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithWronlgyCapitalizedNullDefaultValue.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+
+trait MethodInTraitWithParameterWithWronlgyCapitalizedNullDefaultValue
+{
+    public function foo($bar = NuLl)
+    {
+        return $bar;
+    }
+}

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithoutDefaultValue.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithoutDefaultValue.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+
+trait MethodInTraitWithParameterWithoutDefaultValue
+{
+    public function foo($bar)
+    {
+        return $bar;
+    }
+}

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithoutParameters.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithoutParameters.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+
+trait MethodInTraitWithoutParameters
+{
+    public function foo()
+    {
+    }
+}

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/method-in-anonymous-class-with-parameter-with-non-null-default-value.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/method-in-anonymous-class-with-parameter-with-non-null-default-value.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+
+new class() {
+    public function foo($bar = true)
+    {
+        return $bar;
+    }
+};

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/method-in-anonymous-class-with-parameter-without-default-value.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/method-in-anonymous-class-with-parameter-without-default-value.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+
+new class() {
+    public function foo($bar)
+    {
+        return $bar;
+    }
+};

--- a/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/method-in-anonymous-class-without-parameters.php
+++ b/test/Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/method-in-anonymous-class-without-parameters.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullDefaultValueRule\Success;
+
+new class() {
+    public function foo()
+    {
+    }
+};

--- a/test/Integration/Methods/NoParameterWithNullDefaultValueRuleTest.php
+++ b/test/Integration/Methods/NoParameterWithNullDefaultValueRuleTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Integration\Methods;
+
+use Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule;
+use Localheinz\PHPStan\Rules\Test\Fixture;
+use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use PHPStan\Rules\Rule;
+
+/**
+ * @internal
+ */
+final class NoParameterWithNullDefaultValueRuleTest extends AbstractTestCase
+{
+    public function providerAnalysisSucceeds(): \Generator
+    {
+        $paths = [
+            'method-in-anonymous-class-with-parameter-with-non-null-default-value' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/method-in-anonymous-class-with-parameter-with-non-null-default-value.php',
+            'method-in-anonymous-class-with-parameter-without-default-value' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/method-in-anonymous-class-with-parameter-without-default-value.php',
+            'method-in-anonymous-class-without-parameters' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/method-in-anonymous-class-without-parameters.php',
+            'method-in-class-with-parameter-with-non-null-default-value' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInClassWithParameterWithNonNullDefaultValue.php',
+            'method-in-class-with-parameter-without-default-value' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInClassWithParameterWithoutDefaultValue.php',
+            'method-in-class-without-parameters' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInClassWithoutParameters.php',
+            'method-in-interface-with-parameter-with-non-null-default-value' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInInterfaceWithParameterWithNonNullDefaultValue.php',
+            'method-in-interface-with-parameter-without-default-value' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInInterfaceWithParameterWithoutDefaultValue.php',
+            'method-in-interface-without-parameters' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInInterfaceWithoutParameters.php',
+            // traits are not supported
+            'method-in-trait-with-parameter-with-default-value' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithDefaultValue.php',
+            'method-in-trait-with-parameter-with-non-null-default-value' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithNonNullDefaultValue.php',
+            'method-in-trait-with-parameter-with-root-namespace-referenced-value' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithRootNamespaceReferencedNullDefaultValue.php',
+            'method-in-trait-with-parameter-with-wrongly-capitalized-null-default-value' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithWronlgyCapitalizedNullDefaultValue.php',
+            'method-in-trait-with-parameter-without-default-value' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithParameterWithoutDefaultValue.php',
+            'method-in-trait-without-parameters' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/MethodInTraitWithoutParameters.php',
+        ];
+
+        foreach ($paths as $description => $path) {
+            yield $description => [
+                $path,
+            ];
+        }
+    }
+
+    public function providerAnalysisFails(): \Generator
+    {
+        $paths = [
+            'method-in-anonymous-class-with-parameter-with-null-default-value' => [
+                __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/method-in-anonymous-class-with-parameter-with-null-default-value.php',
+                [
+                    'Parameter "$bar" of method "foo()" in anonymous class should not have null as default value.',
+                    8,
+                ],
+            ],
+            'method-in-anonymous-class-with-parameter-with-root-namespace-referenced-null-default-value' => [
+                __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/method-in-anonymous-class-with-parameter-with-root-namespace-referenced-null-default-value.php',
+                [
+                    'Parameter "$bar" of method "foo()" in anonymous class should not have null as default value.',
+                    8,
+                ],
+            ],
+            'method-in-anonymous-class-with-parameter-with-wrongly-capitalized-null-default-value' => [
+                __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/method-in-anonymous-class-with-parameter-with-wrongly-capitalized-null-default-value.php',
+                [
+                    'Parameter "$bar" of method "foo()" in anonymous class should not have null as default value.',
+                    8,
+                ],
+            ],
+            'method-in-class-with-parameter-with-null-default-value' => [
+                __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInClassWithParameterWithNullDefaultValue.php',
+                [
+                    \sprintf(
+                        'Parameter "$bar" of method "%s::foo()" should not have null as default value.',
+                        Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure\MethodInClassWithParameterWithNullDefaultValue::class
+                    ),
+                    9,
+                ],
+            ],
+            'method-in-class-with-parameter-with-root-namespace-referenced-null-default-value' => [
+                __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInClassWithParameterWithRootNamespaceReferencedNullDefaultValue.php',
+                [
+                    \sprintf(
+                        'Parameter "$bar" of method "%s::foo()" should not have null as default value.',
+                        Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure\MethodInClassWithParameterWithRootNamespaceReferencedNullDefaultValue::class
+                    ),
+                    9,
+                ],
+            ],
+            'method-in-class-with-parameter-with-wrongly-capitalized-null-default-value' => [
+                __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInClassWithParameterWithWronglyCapitalizedNullDefaultValue.php',
+                [
+                    \sprintf(
+                        'Parameter "$bar" of method "%s::foo()" should not have null as default value.',
+                        Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure\MethodInClassWithParameterWithWronglyCapitalizedNullDefaultValue::class
+                    ),
+                    9,
+                ],
+            ],
+            'method-in-interface-with-parameter-with-null-default-value' => [
+                __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInInterfaceWithParameterWithNullDefaultValue.php',
+                [
+                    \sprintf(
+                        'Parameter "$bar" of method "%s::foo()" should not have null as default value.',
+                        Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure\MethodInInterfaceWithParameterWithNullDefaultValue::class
+                    ),
+                    9,
+                ],
+            ],
+            'method-in-interface-with-parameter-with-root-namespace-referenced-null-default-value' => [
+                __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInInterfaceWithParameterWithRootNamespaceReferencedNullDefaultValue.php',
+                [
+                    \sprintf(
+                        'Parameter "$bar" of method "%s::foo()" should not have null as default value.',
+                        Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure\MethodInInterfaceWithParameterWithRootNamespaceReferencedNullDefaultValue::class
+                    ),
+                    9,
+                ],
+            ],
+            'method-in-interface-with-parameter-wrongly-capitalized-null-default-value' => [
+                __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Failure/MethodInInterfaceWithParameterWithWronlgyCapitalizedNullDefaultValue.php',
+                [
+                    \sprintf(
+                        'Parameter "$bar" of method "%s::foo()" should not have null as default value.',
+                        Fixture\Methods\NoParameterWithNullDefaultValueRule\Failure\MethodInInterfaceWithParameterWithWronlgyCapitalizedNullDefaultValue::class
+                    ),
+                    9,
+                ],
+            ],
+        ];
+
+        foreach ($paths as $description => [$path, $error]) {
+            yield $description => [
+                $path,
+                $error,
+            ];
+        }
+    }
+
+    protected function getRule(): Rule
+    {
+        return new NoParameterWithNullDefaultValueRule();
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements `Methods\NoParameterWithNullDefaultValueRule`, which reports an error when a method declared in an anonymous class, a class, or an interface has a parameter with `null` as default value