### PR TITLE
Enhancement: Implement Functions\NoParameterWithNullableTypeDeclarationRule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,7 +129,7 @@ jobs:
         - xdebug-enable
 
       script:
-        - vendor/bin/infection --min-covered-msi=94 --min-msi=94
+        - vendor/bin/infection --min-covered-msi=95 --min-msi=95
 
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ For a full diff see [`0.2.0...master`](https://github.com/localheinz/phpstan-rul
   has a parameter with `null` as default value ([#32](https://github.com/localheinz/phpstan-rules/pull/32)), by [@localheinz](https://github.com/localheinz)
 * added `Closures\NoParameterWithNullableTypeDeclarationRule`, which reports an
   error when a closure has a parameter with a nullable type declaration ([#33](https://github.com/localheinz/phpstan-rules/pull/33)), by [@localheinz](https://github.com/localheinz)
+* added `Functions\NoParameterWithNullableTypeDeclarationRule`, which reports an
+  error when a function has a parameter with a nullable type declaration ([#34](https://github.com/localheinz/phpstan-rules/pull/34)), by [@localheinz](https://github.com/localheinz)
 
 ## [`0.2.0`](https://github.com/localheinz/phpstan-rules/releases/tag/0.2.0)
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ cs: vendor
 	vendor/bin/php-cs-fixer fix --config=.php_cs.fixture --diff --verbose
 
 infection: vendor
-	vendor/bin/infection --min-covered-msi=94 --min-msi=94
+	vendor/bin/infection --min-covered-msi=95 --min-msi=95
 
 stan: vendor
 	vendor/bin/phpstan analyse --configuration=phpstan.neon --level=max src

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This package provides the following rules for use with [`phpstan/phpstan`](https
 * [`Localheinz\PHPStan\Rules\Closures\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#closuresnoparameterwithnulldefaultvaluerule)
 * [`Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#functionsnonullablereturntypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#functionsnoparameterwithnulldefaultvaluerule)
+* [`Localheinz\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclaration`](https://github.com/localheinz/phpstan-rules#functionsnoparameterwithnullabletypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#methodsnonullablereturntypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#methodsnoparameterwithnulldefaultvaluerule)
 
@@ -121,6 +122,17 @@ If you want to use this rule, add it to your `phpstan.neon`:
 ```neon
 rules:
 	- Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule
+```
+
+### `Functions\NoParameterWithNullableTypeDeclarationRule`
+
+This rule reports an error when a function has a parameter with a nullable type declaration.
+
+If you want to use this rule, add it to your `phpstan.neon`:
+
+```neon
+rules:
+	- Localheinz\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclarationRule
 ```
 
 ### `Functions\NoParameterWithNullDefaultValueRule`

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,5 +7,6 @@ rules:
 	- Localheinz\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule
+	- Localheinz\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule

--- a/src/Functions/NoParameterWithNullableTypeDeclarationRule.php
+++ b/src/Functions/NoParameterWithNullableTypeDeclarationRule.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Functions;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+
+final class NoParameterWithNullableTypeDeclarationRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Stmt\Function_::class;
+    }
+
+    /**
+     * @param Node\Stmt\Function_ $node
+     * @param Scope               $scope
+     *
+     * @return array
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (0 === \count($node->params)) {
+            return [];
+        }
+
+        $params = \array_filter($node->params, static function (Node\Param $node): bool {
+            return $node->type instanceof Node\NullableType;
+        });
+
+        if (0 === \count($params)) {
+            return [];
+        }
+
+        $functionName = $node->namespacedName;
+
+        return \array_map(static function (Node\Param $node) use ($functionName): string {
+            /** @var Node\Expr\Variable $variable */
+            $variable = $node->var;
+
+            /** @var string $parameterName */
+            $parameterName = $variable->name;
+
+            return \sprintf(
+                'Parameter "$%s" of function "%s()" should not have a nullable type declaration.',
+                $parameterName,
+                $functionName
+            );
+        }, $params);
+    }
+}

--- a/test/Fixture/Functions/NoParameterWithNullableTypeDeclarationRule/Failure/function-with-parameter-with-nullable-type-declaration.php
+++ b/test/Fixture/Functions/NoParameterWithNullableTypeDeclarationRule/Failure/function-with-parameter-with-nullable-type-declaration.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullableTypeDeclarationRule\Failure;
+
+function foo(?string $bar)
+{
+    return $bar;
+}

--- a/test/Fixture/Functions/NoParameterWithNullableTypeDeclarationRule/Success/function-with-parameter-with-type-declaration.php
+++ b/test/Fixture/Functions/NoParameterWithNullableTypeDeclarationRule/Success/function-with-parameter-with-type-declaration.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullableTypeDeclarationRule\Success;
+
+function foo(string $bar)
+{
+    return $bar;
+}

--- a/test/Fixture/Functions/NoParameterWithNullableTypeDeclarationRule/Success/function-with-parameter-without-type-declaration.php
+++ b/test/Fixture/Functions/NoParameterWithNullableTypeDeclarationRule/Success/function-with-parameter-without-type-declaration.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullableTypeDeclarationRule\Success;
+
+function foo($bar)
+{
+    return $bar;
+}

--- a/test/Fixture/Functions/NoParameterWithNullableTypeDeclarationRule/Success/function-without-parameters.php
+++ b/test/Fixture/Functions/NoParameterWithNullableTypeDeclarationRule/Success/function-without-parameters.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullableTypeDeclarationRule\Success;
+
+function foo()
+{
+}

--- a/test/Integration/Functions/NoParameterWithNullableTypeDeclarationRuleTest.php
+++ b/test/Integration/Functions/NoParameterWithNullableTypeDeclarationRuleTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Integration\Functions;
+
+use Localheinz\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclarationRule;
+use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use PHPStan\Rules\Rule;
+
+/**
+ * @internal
+ */
+final class NoParameterWithNullableTypeDeclarationRuleTest extends AbstractTestCase
+{
+    public function providerAnalysisSucceeds(): \Generator
+    {
+        $paths = [
+            'function-with-parameter-with-type-declaration' => __DIR__ . '/../../Fixture/Functions/NoParameterWithNullableTypeDeclarationRule/Success/function-with-parameter-with-type-declaration.php',
+            'function-with-parameter-without-type-declaration' => __DIR__ . '/../../Fixture/Functions/NoParameterWithNullableTypeDeclarationRule/Success/function-with-parameter-without-type-declaration.php',
+            'function-without-parameters' => __DIR__ . '/../../Fixture/Functions/NoParameterWithNullableTypeDeclarationRule/Success/function-without-parameters.php',
+        ];
+
+        foreach ($paths as $description => $path) {
+            yield $description => [
+                $path,
+            ];
+        }
+    }
+
+    public function providerAnalysisFails(): \Generator
+    {
+        $paths = [
+            'function-with-parameter-with-nullable-type-declaration' => [
+                __DIR__ . '/../../Fixture/Functions/NoParameterWithNullableTypeDeclarationRule/Failure/function-with-parameter-with-nullable-type-declaration.php',
+                [
+                    'Parameter "$bar" of function "Localheinz\PHPStan\Rules\Test\Fixture\Functions\NoParameterWithNullableTypeDeclarationRule\Failure\foo()" should not have a nullable type declaration.',
+                    7,
+                ],
+            ],
+        ];
+
+        foreach ($paths as $description => [$path, $error]) {
+            yield $description => [
+                $path,
+                $error,
+            ];
+        }
+    }
+
+    protected function getRule(): Rule
+    {
+        return new NoParameterWithNullableTypeDeclarationRule();
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements `Functions\NoParameterWithNullableTypeDeclarationRule`, which reports an error when a function has a parameter with a nullable type declaration