### PR TITLE
Enhancement: Implement Methods\NoParameterWithNullableTypeDeclarationRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ For a full diff see [`0.2.0...master`](https://github.com/localheinz/phpstan-rul
   error when a closure has a parameter with a nullable type declaration ([#33](https://github.com/localheinz/phpstan-rules/pull/33)), by [@localheinz](https://github.com/localheinz)
 * added `Functions\NoParameterWithNullableTypeDeclarationRule`, which reports an
   error when a function has a parameter with a nullable type declaration ([#34](https://github.com/localheinz/phpstan-rules/pull/34)), by [@localheinz](https://github.com/localheinz)
+* added `Methods\NoParameterWithNullableTypeDeclarationRule`, which reports an
+  error when a method declared on an anonymous class, a class, or an interface
+  has a parameter with a nullable type declaration ([#35](https://github.com/localheinz/phpstan-rules/pull/35)), by [@localheinz](https://github.com/localheinz)
 
 ## [`0.2.0`](https://github.com/localheinz/phpstan-rules/releases/tag/0.2.0)
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This package provides the following rules for use with [`phpstan/phpstan`](https
 * [`Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#functionsnoparameterwithnulldefaultvaluerule)
 * [`Localheinz\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclaration`](https://github.com/localheinz/phpstan-rules#functionsnoparameterwithnullabletypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#methodsnonullablereturntypedeclarationrule)
+* [`Localheinz\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#methodsnoparameterwithnullabletypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#methodsnoparameterwithnulldefaultvaluerule)
 
 ### `Classes\AbstractOrFinalRule`
@@ -155,6 +156,17 @@ If you want to use this rule, add it to your `phpstan.neon`:
 ```neon
 rules:
 	- Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule
+```
+
+### `Methods\NoParameterWithNullableTypeDeclarationRule`
+
+This rule reports an error when a method declared in an anonymous class, a class, or an interface has a parameter with a nullable type declaration.
+
+If you want to use this rule, add it to your `phpstan.neon`:
+
+```neon
+rules:
+	- Localheinz\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule
 ```
 
 ### `Methods\NoParameterWithNullDefaultValueRule`

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,3 +10,4 @@ rules:
 	- Localheinz\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule
+	- Localheinz\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule

--- a/src/Methods/NoParameterWithNullableTypeDeclarationRule.php
+++ b/src/Methods/NoParameterWithNullableTypeDeclarationRule.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Methods;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection;
+use PHPStan\Rules\Rule;
+
+final class NoParameterWithNullableTypeDeclarationRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Stmt\ClassMethod::class;
+    }
+
+    /**
+     * @param Node\Stmt\ClassMethod $node
+     * @param Scope                 $scope
+     *
+     * @return array
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (0 === \count($node->params)) {
+            return [];
+        }
+
+        $params = \array_filter($node->params, static function (Node\Param $node): bool {
+            return $node->type instanceof Node\NullableType;
+        });
+
+        if (0 === \count($params)) {
+            return [];
+        }
+
+        $methodName = $node->name->toString();
+
+        /** @var Reflection\ClassReflection $classReflection */
+        $classReflection = $scope->getClassReflection();
+
+        if ($classReflection->isAnonymous()) {
+            return \array_map(static function (Node\Param $node) use ($methodName): string {
+                /** @var Node\Expr\Variable $variable */
+                $variable = $node->var;
+
+                /** @var string $parameterName */
+                $parameterName = $variable->name;
+
+                return \sprintf(
+                    'Parameter "$%s" of method "%s()" in anonymous class should not have a nullable type declaration.',
+                    $parameterName,
+                    $methodName
+                );
+            }, $params);
+        }
+
+        $className = $classReflection->getName();
+
+        return \array_map(static function (Node\Param $node) use ($className, $methodName): string {
+            /** @var Node\Expr\Variable $variable */
+            $variable = $node->var;
+
+            /** @var string $parameterName */
+            $parameterName = $variable->name;
+
+            return \sprintf(
+                'Parameter "$%s" of method "%s::%s()" should not have a nullable type declaration.',
+                $parameterName,
+                $className,
+                $methodName
+            );
+        }, $params);
+    }
+}

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Failure/MethodInClassWithParameterWithNullableTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Failure/MethodInClassWithParameterWithNullableTypeDeclaration.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Failure;
+
+final class MethodInClassWithParameterWithNullableTypeDeclaration
+{
+    public function foo(?string $bar)
+    {
+        return $bar;
+    }
+}

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Failure/MethodInInterfaceWithParameterWithNullableTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Failure/MethodInInterfaceWithParameterWithNullableTypeDeclaration.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Failure;
+
+interface MethodInInterfaceWithParameterWithNullableTypeDeclaration
+{
+    public function foo(?string $bar);
+}

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Failure/method-in-anonymous-class-with-parameter-with-nullable-type-declaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Failure/method-in-anonymous-class-with-parameter-with-nullable-type-declaration.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+
+new class() {
+    public function foo(?string $bar)
+    {
+        return $bar;
+    }
+};

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInClassWithParameterWithTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInClassWithParameterWithTypeDeclaration.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+
+final class MethodInClassWithParameterWithTypeDeclaration
+{
+    public function foo(string $bar)
+    {
+        return $bar;
+    }
+}

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInClassWithParameterWithoutTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInClassWithParameterWithoutTypeDeclaration.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+
+final class MethodInClassWithParameterWithoutTypeDeclaration
+{
+    public function foo($bar)
+    {
+        return $bar;
+    }
+}

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInClassWithoutParameters.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInClassWithoutParameters.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+
+final class MethodInClassWithoutParameters
+{
+    public function foo()
+    {
+    }
+}

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInInterfaceWithParameterWithTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInInterfaceWithParameterWithTypeDeclaration.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+
+interface MethodInInterfaceWithParameterWithTypeDeclaration
+{
+    public function foo(string $bar);
+}

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInInterfaceWithParameterWithoutTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInInterfaceWithParameterWithoutTypeDeclaration.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+
+interface MethodInInterfaceWithParameterWithoutTypeDeclaration
+{
+    public function foo($bar);
+}

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInInterfaceWithoutParameters.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInInterfaceWithoutParameters.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+
+interface MethodInInterfaceWithoutParameters
+{
+    public function foo();
+}

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInTraitWithParameterWithNullableTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInTraitWithParameterWithNullableTypeDeclaration.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+
+trait MethodInTraitWithParameterWithNullableTypeDeclaration
+{
+    public function foo(?string $bar)
+    {
+        return $bar;
+    }
+}

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInTraitWithParameterWithTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInTraitWithParameterWithTypeDeclaration.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+
+trait MethodInTraitWithParameterWithTypeDeclaration
+{
+    public function foo(string $bar)
+    {
+        return $bar;
+    }
+}

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInTraitWithParameterWithoutTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInTraitWithParameterWithoutTypeDeclaration.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+
+trait MethodInTraitWithParameterWithoutTypeDeclaration
+{
+    public function foo($bar)
+    {
+        return $bar;
+    }
+}

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInTraitWithoutParameters.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInTraitWithoutParameters.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+
+trait MethodInTraitWithoutParameters
+{
+    public function foo()
+    {
+    }
+}

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/method-in-anonymous-class-with-parameter-with-type-declaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/method-in-anonymous-class-with-parameter-with-type-declaration.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+
+new class() {
+    public function foo(string $bar)
+    {
+        return $bar;
+    }
+};

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/method-in-anonymous-class-with-parameter-without-type-declaration.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/method-in-anonymous-class-with-parameter-without-type-declaration.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+
+new class() {
+    public function foo($bar)
+    {
+        return $bar;
+    }
+};

--- a/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/method-in-anonymous-class-without-parameters.php
+++ b/test/Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/method-in-anonymous-class-without-parameters.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Success;
+
+new class() {
+    public function foo()
+    {
+    }
+};

--- a/test/Integration/Methods/NoParameterWithNullableTypeDeclarationRuleTest.php
+++ b/test/Integration/Methods/NoParameterWithNullableTypeDeclarationRuleTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Integration\Methods;
+
+use Localheinz\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule;
+use Localheinz\PHPStan\Rules\Test\Fixture;
+use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use PHPStan\Rules\Rule;
+
+/**
+ * @internal
+ */
+final class NoParameterWithNullableTypeDeclarationRuleTest extends AbstractTestCase
+{
+    public function providerAnalysisSucceeds(): \Generator
+    {
+        $paths = [
+            'method-in-anonymous-class-with-parameter-with-type-declaration' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/method-in-anonymous-class-with-parameter-with-type-declaration.php',
+            'method-in-anonymous-class-with-parameter-without-type-declaration' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/method-in-anonymous-class-with-parameter-without-type-declaration.php',
+            'method-in-anonymous-class-without-parameters' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/method-in-anonymous-class-without-parameters.php',
+            'method-in-class-with-parameter-with-type-declaration' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInClassWithParameterWithTypeDeclaration.php',
+            'method-in-class-with-parameter-without-type-declaration' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInClassWithParameterWithoutTypeDeclaration.php',
+            'method-in-class-without-parameters' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInClassWithoutParameters.php',
+            'method-in-interface-with-parameter-with-type-declaration' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInInterfaceWithParameterWithTypeDeclaration.php',
+            'method-in-interface-with-parameter-without-type-declaration' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInInterfaceWithParameterWithoutTypeDeclaration.php',
+            'method-in-interface-without-parameters' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInInterfaceWithoutParameters.php',
+            // traits are not supported
+            'method-in-trait-with-parameter-with-type-declaration' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInTraitWithParameterWithTypeDeclaration.php',
+            'method-in-trait-with-parameter-without-type-declaration' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInTraitWithParameterWithoutTypeDeclaration.php',
+            'method-in-trait-without-parameters' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/MethodInTraitWithoutParameters.php',
+        ];
+
+        foreach ($paths as $description => $path) {
+            yield $description => [
+                $path,
+            ];
+        }
+    }
+
+    public function providerAnalysisFails(): \Generator
+    {
+        $paths = [
+            'method-in-anonymous-class-with-parameter-with-nullable-type-declaration' => [
+                __DIR__ . '/../../Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Failure/method-in-anonymous-class-with-parameter-with-nullable-type-declaration.php',
+                [
+                    'Parameter "$bar" of method "foo()" in anonymous class should not have a nullable type declaration.',
+                    8,
+                ],
+            ],
+            'method-in-class-with-parameter-with-nullable-type-declaration' => [
+                __DIR__ . '/../../Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Failure/MethodInClassWithParameterWithNullableTypeDeclaration.php',
+                [
+                    \sprintf(
+                        'Parameter "$bar" of method "%s::foo()" should not have a nullable type declaration.',
+                        Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Failure\MethodInClassWithParameterWithNullableTypeDeclaration::class
+                    ),
+                    9,
+                ],
+            ],
+            'method-in-interface-with-parameter-with-nullable-type-declaration' => [
+                __DIR__ . '/../../Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Failure/MethodInInterfaceWithParameterWithNullableTypeDeclaration.php',
+                [
+                    \sprintf(
+                        'Parameter "$bar" of method "%s::foo()" should not have a nullable type declaration.',
+                        Fixture\Methods\NoParameterWithNullableTypeDeclarationRule\Failure\MethodInInterfaceWithParameterWithNullableTypeDeclaration::class
+                    ),
+                    9,
+                ],
+            ],
+        ];
+
+        foreach ($paths as $description => [$path, $error]) {
+            yield $description => [
+                $path,
+                $error,
+            ];
+        }
+    }
+
+    protected function getRule(): Rule
+    {
+        return new NoParameterWithNullableTypeDeclarationRule();
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements `Methods\NoParameterWithNullableTypeDeclarationRule`, which reports an error when a method declared on an anonymous class, a class, or an interface has a parameter with a nullable type declaration