### PR TITLE
Fix: Wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ For a full diff see [`0.2.0...master`](https://github.com/localheinz/phpstan-rul
 * added `Functions\NoNullableReturnTypeDeclarationRule`, which reports an
   error when a function has a nullable return type declaration, and
   `Methods\NoNullableReturnTypeDeclarationRule`, which reports an error
-  when a method declared on an anonymous class, a class, or an interface has a
+  when a method declared in an anonymous class, a class, or an interface has a
   nullable return type declaration ([#16](https://github.com/localheinz/phpstan-rules/pull/16)), by [@localheinz](https://github.com/localheinz)
 * added `Closures\NoParameterWithNullDefaultValueRule`, which reports an
   error when a closure has a parameter with `null` as default value ([#26](https://github.com/localheinz/phpstan-rules/pull/26)), by [@localheinz](https://github.com/localheinz)
@@ -23,14 +23,14 @@ For a full diff see [`0.2.0...master`](https://github.com/localheinz/phpstan-rul
 * added `Functions\NoParameterWithNullDefaultValueRule`, which reports an
   error when a function has a parameter with `null` as default value ([#31](https://github.com/localheinz/phpstan-rules/pull/31)), by [@localheinz](https://github.com/localheinz)
 * added `Methods\NoParameterWithNullDefaultValueRule`, which reports an
-  error when a method declared on an anonymous class, a class, or an interface
+  error when a method declared in an anonymous class, a class, or an interface
   has a parameter with `null` as default value ([#32](https://github.com/localheinz/phpstan-rules/pull/32)), by [@localheinz](https://github.com/localheinz)
 * added `Closures\NoParameterWithNullableTypeDeclarationRule`, which reports an
   error when a closure has a parameter with a nullable type declaration ([#33](https://github.com/localheinz/phpstan-rules/pull/33)), by [@localheinz](https://github.com/localheinz)
 * added `Functions\NoParameterWithNullableTypeDeclarationRule`, which reports an
   error when a function has a parameter with a nullable type declaration ([#34](https://github.com/localheinz/phpstan-rules/pull/34)), by [@localheinz](https://github.com/localheinz)
 * added `Methods\NoParameterWithNullableTypeDeclarationRule`, which reports an
-  error when a method declared on an anonymous class, a class, or an interface
+  error when a method declared in an anonymous class, a class, or an interface
   has a parameter with a nullable type declaration ([#35](https://github.com/localheinz/phpstan-rules/pull/35)), by [@localheinz](https://github.com/localheinz)
 
 ## [`0.2.0`](https://github.com/localheinz/phpstan-rules/releases/tag/0.2.0)

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ rules:
 
 ### `Methods\NoNullableReturnTypeDeclarationRule`
 
-This rule reports an error when a method declared on an anonymous class, a class, or an interface uses a nullable return type declaration.
+This rule reports an error when a method declared in an anonymous class, a class, or an interface uses a nullable return type declaration.
 
 If you want to use this rule, add it to your `phpstan.neon`:
 


### PR DESCRIPTION
This PR

* [x] fixes the wording (`on` vs. `in`) a bit 