### PR TITLE
Enhancement: Extract rules.neon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 For a full diff see [`0.2.0...master`](https://github.com/localheinz/phpstan-rules/compare/0.2.0...master).
 
+## [`0.3.0`](https://github.com/localheinz/phpstan-rules/releases/tag/0.3.0)
+
+For a full diff see [`0.2.0...0.3.0`](https://github.com/localheinz/phpstan-rules/compare/0.2.0...0.3.0).
+
 ### Added
 
 * added `Functions\NoNullableReturnTypeDeclarationRule`, which reports an
@@ -32,6 +36,8 @@ For a full diff see [`0.2.0...master`](https://github.com/localheinz/phpstan-rul
 * added `Methods\NoParameterWithNullableTypeDeclarationRule`, which reports an
   error when a method declared in an anonymous class, a class, or an interface
   has a parameter with a nullable type declaration ([#35](https://github.com/localheinz/phpstan-rules/pull/35)), by [@localheinz](https://github.com/localheinz)
+* extracted `rules.neon`, so you can easily enable all rules by including it
+  in your `phpstan.neon` ([#37](https://github.com/localheinz/phpstan-rules/pull/37)), by [@localheinz](https://github.com/localheinz)
 
 ## [`0.2.0`](https://github.com/localheinz/phpstan-rules/releases/tag/0.2.0)
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ This package provides the following rules for use with [`phpstan/phpstan`](https
 * [`Localheinz\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#methodsnoparameterwithnullabletypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#methodsnoparameterwithnulldefaultvaluerule)
 
+:bulb: If you want to use all of these rules, include [`rules.neon`](rules.neon) in your `phpstan.neon`:
+
+```neon
+includes:
+	- vendor/localheinz/phpstan-rules/rules.neon
+```
+
+You probably want to use these rules on top of [`phpstan/phpstan-strict-rules`](https://github.com/phpstan/phpstan-strict-rules).
+
 ### `Classes\AbstractOrFinalRule`
 
 This rule reports an error when a non-anonymous class is neither `abstract` nor `final`.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,13 +1,3 @@
 includes:
 	- vendor/phpstan/phpstan-strict-rules/rules.neon
-
-rules:
-	- Localheinz\PHPStan\Rules\Classes\AbstractOrFinalRule
-	- Localheinz\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule
-	- Localheinz\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule
-	- Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule
-	- Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule
-	- Localheinz\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclarationRule
-	- Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule
-	- Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule
-	- Localheinz\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule
+	- rules.neon

--- a/rules.neon
+++ b/rules.neon
@@ -1,0 +1,10 @@
+rules:
+	- Localheinz\PHPStan\Rules\Classes\AbstractOrFinalRule
+	- Localheinz\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule
+	- Localheinz\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule
+	- Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule
+	- Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule
+	- Localheinz\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclarationRule
+	- Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule
+	- Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule
+	- Localheinz\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule


### PR DESCRIPTION
This PR

* [x] extracts `rules.neon`, so enabling of rules is easier