### PR TITLE
Fix: Do not bother with wrapping content in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
@@ -15,29 +14,15 @@ For a full diff see [`0.2.0...0.3.0`](https://github.com/localheinz/phpstan-rule
 
 ### Added
 
-* added `Functions\NoNullableReturnTypeDeclarationRule`, which reports an
-  error when a function has a nullable return type declaration, and
-  `Methods\NoNullableReturnTypeDeclarationRule`, which reports an error
-  when a method declared in an anonymous class, a class, or an interface has a
-  nullable return type declaration ([#16](https://github.com/localheinz/phpstan-rules/pull/16)), by [@localheinz](https://github.com/localheinz)
-* added `Closures\NoParameterWithNullDefaultValueRule`, which reports an
-  error when a closure has a parameter with `null` as default value ([#26](https://github.com/localheinz/phpstan-rules/pull/26)), by [@localheinz](https://github.com/localheinz)
-* added `Closures\NoNullableReturnTypeDeclarationRule`, which reports an
-  error when a closure has a nullable return type declaration ([#29](https://github.com/localheinz/phpstan-rules/pull/29)), by [@localheinz](https://github.com/localheinz)
-* added `Functions\NoParameterWithNullDefaultValueRule`, which reports an
-  error when a function has a parameter with `null` as default value ([#31](https://github.com/localheinz/phpstan-rules/pull/31)), by [@localheinz](https://github.com/localheinz)
-* added `Methods\NoParameterWithNullDefaultValueRule`, which reports an
-  error when a method declared in an anonymous class, a class, or an interface
-  has a parameter with `null` as default value ([#32](https://github.com/localheinz/phpstan-rules/pull/32)), by [@localheinz](https://github.com/localheinz)
-* added `Closures\NoParameterWithNullableTypeDeclarationRule`, which reports an
-  error when a closure has a parameter with a nullable type declaration ([#33](https://github.com/localheinz/phpstan-rules/pull/33)), by [@localheinz](https://github.com/localheinz)
-* added `Functions\NoParameterWithNullableTypeDeclarationRule`, which reports an
-  error when a function has a parameter with a nullable type declaration ([#34](https://github.com/localheinz/phpstan-rules/pull/34)), by [@localheinz](https://github.com/localheinz)
-* added `Methods\NoParameterWithNullableTypeDeclarationRule`, which reports an
-  error when a method declared in an anonymous class, a class, or an interface
-  has a parameter with a nullable type declaration ([#35](https://github.com/localheinz/phpstan-rules/pull/35)), by [@localheinz](https://github.com/localheinz)
-* extracted `rules.neon`, so you can easily enable all rules by including it
-  in your `phpstan.neon` ([#37](https://github.com/localheinz/phpstan-rules/pull/37)), by [@localheinz](https://github.com/localheinz)
+* added `Functions\NoNullableReturnTypeDeclarationRule`, which reports an error when a function has a nullable return type declaration, and `Methods\NoNullableReturnTypeDeclarationRule`, which reports an error when a method declared in an anonymous class, a class, or an interface has a nullable return type declaration ([#16](https://github.com/localheinz/phpstan-rules/pull/16)), by [@localheinz](https://github.com/localheinz)
+* added `Closures\NoParameterWithNullDefaultValueRule`, which reports an error when a closure has a parameter with `null` as default value ([#26](https://github.com/localheinz/phpstan-rules/pull/26)), by [@localheinz](https://github.com/localheinz)
+* added `Closures\NoNullableReturnTypeDeclarationRule`, which reports an error when a closure has a nullable return type declaration ([#29](https://github.com/localheinz/phpstan-rules/pull/29)), by [@localheinz](https://github.com/localheinz)
+* added `Functions\NoParameterWithNullDefaultValueRule`, which reports an error when a function has a parameter with `null` as default value ([#31](https://github.com/localheinz/phpstan-rules/pull/31)), by [@localheinz](https://github.com/localheinz)
+* added `Methods\NoParameterWithNullDefaultValueRule`, which reports an error when a method declared in an anonymous class, a class, or an interface has a parameter with `null` as default value ([#32](https://github.com/localheinz/phpstan-rules/pull/32)), by [@localheinz](https://github.com/localheinz)
+* added `Closures\NoParameterWithNullableTypeDeclarationRule`, which reports an error when a closure has a parameter with a nullable type declaration ([#33](https://github.com/localheinz/phpstan-rules/pull/33)), by [@localheinz](https://github.com/localheinz)
+* added `Functions\NoParameterWithNullableTypeDeclarationRule`, which reports an error when a function has a parameter with a nullable type declaration ([#34](https://github.com/localheinz/phpstan-rules/pull/34)), by [@localheinz](https://github.com/localheinz)
+* added `Methods\NoParameterWithNullableTypeDeclarationRule`, which reports an error when a method declared in an anonymous class, a class, or an interface has a parameter with a nullable type declaration ([#35](https://github.com/localheinz/phpstan-rules/pull/35)), by [@localheinz](https://github.com/localheinz)
+* extracted `rules.neon`, so you can easily enable all rules by including it in your `phpstan.neon` ([#37](https://github.com/localheinz/phpstan-rules/pull/37)), by [@localheinz](https://github.com/localheinz)
 
 ## [`0.2.0`](https://github.com/localheinz/phpstan-rules/releases/tag/0.2.0)
 
@@ -45,13 +30,11 @@ For a full diff see [`0.1.0...0.2.0`](https://github.com/localheinz/phpstan-rule
 
 ### Added
 
-* added `Classes\FinalRule`, which reports an error when a non-anonymous
-  class is not `final`, ([#4](https://github.com/localheinz/phpstan-rules/pull/4)), by [@localheinz](https://github.com/localheinz)
+* added `Classes\FinalRule`, which reports an error when a non-anonymous class is not `final`, ([#4](https://github.com/localheinz/phpstan-rules/pull/4)), by [@localheinz](https://github.com/localheinz)
 
 ### Changed
 
-* added an `$excludeClassNames` argument to the constructors of `Classes\AbstractOrFinalRule` and
-  `Classes\FinalRule` to allow whitelisting of classes, ([#4](https://github.com/localheinz/phpstan-rules/pull/11)), by [@localheinz](https://github.com/localheinz)
+* added an `$excludeClassNames` argument to the constructors of `Classes\AbstractOrFinalRule` and `Classes\FinalRule` to allow whitelisting of classes, ([#4](https://github.com/localheinz/phpstan-rules/pull/11)), by [@localheinz](https://github.com/localheinz)
 
 ## [`0.1.0`](https://github.com/localheinz/phpstan-rules/releases/tag/0.1.0)
 
@@ -59,6 +42,5 @@ For a full diff see [`362c7ea...0.1.0`](https://github.com/localheinz/phpstan-ru
 
 ### Added
 
-* added `Classes\AbstractOrFinalRule`, which reports an error when a non-anonymous
-  class is neither `abstract` nor `final`, ([#1](https://github.com/localheinz/phpstan-rules/pull/1)), by [@localheinz](https://github.com/localheinz)
+* added `Classes\AbstractOrFinalRule`, which reports an error when a non-anonymous class is neither `abstract` nor `final`, ([#1](https://github.com/localheinz/phpstan-rules/pull/1)), by [@localheinz](https://github.com/localheinz)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,14 @@ For a full diff see [`0.2.0...0.3.0`](https://github.com/localheinz/phpstan-rule
 
 ### Added
 
-* added `Functions\NoNullableReturnTypeDeclarationRule`, which reports an error when a function has a nullable return type declaration, and `Methods\NoNullableReturnTypeDeclarationRule`, which reports an error when a method declared in an anonymous class, a class, or an interface has a nullable return type declaration ([#16](https://github.com/localheinz/phpstan-rules/pull/16)), by [@localheinz](https://github.com/localheinz)
-* added `Closures\NoParameterWithNullDefaultValueRule`, which reports an error when a closure has a parameter with `null` as default value ([#26](https://github.com/localheinz/phpstan-rules/pull/26)), by [@localheinz](https://github.com/localheinz)
-* added `Closures\NoNullableReturnTypeDeclarationRule`, which reports an error when a closure has a nullable return type declaration ([#29](https://github.com/localheinz/phpstan-rules/pull/29)), by [@localheinz](https://github.com/localheinz)
-* added `Functions\NoParameterWithNullDefaultValueRule`, which reports an error when a function has a parameter with `null` as default value ([#31](https://github.com/localheinz/phpstan-rules/pull/31)), by [@localheinz](https://github.com/localheinz)
-* added `Methods\NoParameterWithNullDefaultValueRule`, which reports an error when a method declared in an anonymous class, a class, or an interface has a parameter with `null` as default value ([#32](https://github.com/localheinz/phpstan-rules/pull/32)), by [@localheinz](https://github.com/localheinz)
-* added `Closures\NoParameterWithNullableTypeDeclarationRule`, which reports an error when a closure has a parameter with a nullable type declaration ([#33](https://github.com/localheinz/phpstan-rules/pull/33)), by [@localheinz](https://github.com/localheinz)
-* added `Functions\NoParameterWithNullableTypeDeclarationRule`, which reports an error when a function has a parameter with a nullable type declaration ([#34](https://github.com/localheinz/phpstan-rules/pull/34)), by [@localheinz](https://github.com/localheinz)
-* added `Methods\NoParameterWithNullableTypeDeclarationRule`, which reports an error when a method declared in an anonymous class, a class, or an interface has a parameter with a nullable type declaration ([#35](https://github.com/localheinz/phpstan-rules/pull/35)), by [@localheinz](https://github.com/localheinz)
+* Added `Functions\NoNullableReturnTypeDeclarationRule`, which reports an error when a function has a nullable return type declaration, and `Methods\NoNullableReturnTypeDeclarationRule`, which reports an error when a method declared in an anonymous class, a class, or an interface has a nullable return type declaration ([#16](https://github.com/localheinz/phpstan-rules/pull/16)), by [@localheinz](https://github.com/localheinz)
+* Added `Closures\NoParameterWithNullDefaultValueRule`, which reports an error when a closure has a parameter with `null` as default value ([#26](https://github.com/localheinz/phpstan-rules/pull/26)), by [@localheinz](https://github.com/localheinz)
+* Added `Closures\NoNullableReturnTypeDeclarationRule`, which reports an error when a closure has a nullable return type declaration ([#29](https://github.com/localheinz/phpstan-rules/pull/29)), by [@localheinz](https://github.com/localheinz)
+* Added `Functions\NoParameterWithNullDefaultValueRule`, which reports an error when a function has a parameter with `null` as default value ([#31](https://github.com/localheinz/phpstan-rules/pull/31)), by [@localheinz](https://github.com/localheinz)
+* Added `Methods\NoParameterWithNullDefaultValueRule`, which reports an error when a method declared in an anonymous class, a class, or an interface has a parameter with `null` as default value ([#32](https://github.com/localheinz/phpstan-rules/pull/32)), by [@localheinz](https://github.com/localheinz)
+* Added `Closures\NoParameterWithNullableTypeDeclarationRule`, which reports an error when a closure has a parameter with a nullable type declaration ([#33](https://github.com/localheinz/phpstan-rules/pull/33)), by [@localheinz](https://github.com/localheinz)
+* Added `Functions\NoParameterWithNullableTypeDeclarationRule`, which reports an error when a function has a parameter with a nullable type declaration ([#34](https://github.com/localheinz/phpstan-rules/pull/34)), by [@localheinz](https://github.com/localheinz)
+* Added `Methods\NoParameterWithNullableTypeDeclarationRule`, which reports an error when a method declared in an anonymous class, a class, or an interface has a parameter with a nullable type declaration ([#35](https://github.com/localheinz/phpstan-rules/pull/35)), by [@localheinz](https://github.com/localheinz)
 * extracted `rules.neon`, so you can easily enable all rules by including it in your `phpstan.neon` ([#37](https://github.com/localheinz/phpstan-rules/pull/37)), by [@localheinz](https://github.com/localheinz)
 
 ## [`0.2.0`](https://github.com/localheinz/phpstan-rules/releases/tag/0.2.0)
@@ -30,11 +30,11 @@ For a full diff see [`0.1.0...0.2.0`](https://github.com/localheinz/phpstan-rule
 
 ### Added
 
-* added `Classes\FinalRule`, which reports an error when a non-anonymous class is not `final`, ([#4](https://github.com/localheinz/phpstan-rules/pull/4)), by [@localheinz](https://github.com/localheinz)
+* Added `Classes\FinalRule`, which reports an error when a non-anonymous class is not `final`, ([#4](https://github.com/localheinz/phpstan-rules/pull/4)), by [@localheinz](https://github.com/localheinz)
 
 ### Changed
 
-* added an `$excludeClassNames` argument to the constructors of `Classes\AbstractOrFinalRule` and `Classes\FinalRule` to allow whitelisting of classes, ([#4](https://github.com/localheinz/phpstan-rules/pull/11)), by [@localheinz](https://github.com/localheinz)
+* Added an `$excludeClassNames` argument to the constructors of `Classes\AbstractOrFinalRule` and `Classes\FinalRule` to allow whitelisting of classes, ([#4](https://github.com/localheinz/phpstan-rules/pull/11)), by [@localheinz](https://github.com/localheinz)
 
 ## [`0.1.0`](https://github.com/localheinz/phpstan-rules/releases/tag/0.1.0)
 
@@ -42,5 +42,5 @@ For a full diff see [`362c7ea...0.1.0`](https://github.com/localheinz/phpstan-ru
 
 ### Added
 
-* added `Classes\AbstractOrFinalRule`, which reports an error when a non-anonymous class is neither `abstract` nor `final`, ([#1](https://github.com/localheinz/phpstan-rules/pull/1)), by [@localheinz](https://github.com/localheinz)
+* Added `Classes\AbstractOrFinalRule`, which reports an error when a non-anonymous class is neither `abstract` nor `final`, ([#1](https://github.com/localheinz/phpstan-rules/pull/1)), by [@localheinz](https://github.com/localheinz)
 


### PR DESCRIPTION
This PR

* [x] removes hard wraps from `CHANGELOG.md`