### PR TITLE
Fix: Keep rules sorted in rules.neon

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -3,8 +3,8 @@ rules:
 	- Localheinz\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule
-	- Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule
 	- Localheinz\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclarationRule
+	- Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule
 	- Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule
-	- Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule
 	- Localheinz\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule
+	- Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule


### PR DESCRIPTION
This PR

* [x] keeps rules sorted in `rules.neon`