### PR TITLE
Enhancement: Implement NoConstructorParameterWithDefaultValueRule

### DIFF
--- a/.php_cs.fixture
+++ b/.php_cs.fixture
@@ -4,6 +4,7 @@ use Localheinz\PhpCsFixer\Config;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71(''), [
     'lowercase_constants' => false,
+    'magic_method_casing' => false,
     'static_lambda' => false,
 ]);
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`0.4.0...master`](https://github.com/localheinz/phpstan-rules/compare/0.4.0...master).
 
+### Added
+
+* Added `Methods\NoConstructorParameterWithDefaultValueRule`, which reports an error when a constructor of an anonymous class or a class has a parameter with a default value ([#45](https://github.com/localheinz/phpstan-rules/pull/45)), by [@localheinz](https://github.com/localheinz)
+
 ## [`0.4.0`](https://github.com/localheinz/phpstan-rules/releases/tag/0.3.0)
 
 For a full diff see [`0.3.0...0.4.0`](https://github.com/localheinz/phpstan-rules/compare/0.3.0...0.4.0).

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This package provides the following rules for use with [`phpstan/phpstan`](https
 * [`Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#functionsnonullablereturntypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#functionsnoparameterwithnulldefaultvaluerule)
 * [`Localheinz\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclaration`](https://github.com/localheinz/phpstan-rules#functionsnoparameterwithnullabletypedeclarationrule)
+* [`Localheinz\PHPStan\Rules\Methods\NoConstructorParameterWithDefaultValueRule`](https://github.com/localheinz/phpstan-rules#methodsnoconstructorparameterwithdefaultvaluerule)
 * [`Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#methodsnonullablereturntypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#methodsnoparameterwithnullabletypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#methodsnoparameterwithnulldefaultvaluerule)
@@ -154,6 +155,17 @@ If you want to use this rule, add it to your `phpstan.neon`:
 ```neon
 rules:
 	- Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule
+```
+
+### `Methods\NoConstructorParameterWithDefaultValueRule`
+
+This rule reports an error when a constructor declared in an anonymous class or a class has a default value.
+
+If you want to use this rule, add it to your `phpstan.neon`:
+
+```neon
+rules:
+	- Localheinz\PHPStan\Rules\Methods\NoConstructorParameterWithDefaultValueRule
 ```
 
 ### `Methods\NoNullableReturnTypeDeclarationRule`

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,8 @@
 includes:
 	- vendor/phpstan/phpstan-strict-rules/rules.neon
 	- rules.neon
+
+parameters:
+	ignoreErrors:
+		- '#Constructor in Localheinz\\PHPStan\\Rules\\Classes\\AbstractOrFinalRule has parameter \$excludedClassNames with default value.#'
+		- '#Constructor in Localheinz\\PHPStan\\Rules\\Classes\\FinalRule has parameter \$excludedClassNames with default value.#'

--- a/rules.neon
+++ b/rules.neon
@@ -5,6 +5,7 @@ rules:
 	- Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule
+	- Localheinz\PHPStan\Rules\Methods\NoConstructorParameterWithDefaultValueRule
 	- Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule

--- a/src/Methods/NoConstructorParameterWithDefaultValueRule.php
+++ b/src/Methods/NoConstructorParameterWithDefaultValueRule.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Methods;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection;
+use PHPStan\Rules\Rule;
+
+final class NoConstructorParameterWithDefaultValueRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Stmt\ClassMethod::class;
+    }
+
+    /**
+     * @param Node\Stmt\ClassMethod $node
+     * @param Scope                 $scope
+     *
+     * @return array
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ('__construct' !== $node->name->toLowerString()) {
+            return [];
+        }
+
+        if (0 === \count($node->params)) {
+            return [];
+        }
+
+        $params = \array_filter($node->params, static function (Node\Param $node): bool {
+            return null !== $node->default;
+        });
+
+        if (0 === \count($params)) {
+            return [];
+        }
+
+        /** @var Reflection\ClassReflection $classReflection */
+        $classReflection = $scope->getClassReflection();
+
+        if ($classReflection->isAnonymous()) {
+            return \array_map(static function (Node\Param $node): string {
+                /** @var Node\Expr\Variable $variable */
+                $variable = $node->var;
+
+                /** @var string $parameterName */
+                $parameterName = $variable->name;
+
+                return \sprintf(
+                    'Constructor in anonymous class has parameter $%s with default value.',
+                    $parameterName
+                );
+            }, $params);
+        }
+
+        $className = $classReflection->getName();
+
+        return \array_map(static function (Node\Param $node) use ($className): string {
+            /** @var Node\Expr\Variable $variable */
+            $variable = $node->var;
+
+            /** @var string $parameterName */
+            $parameterName = $variable->name;
+
+            return \sprintf(
+                'Constructor in %s has parameter $%s with default value.',
+                $className,
+                $parameterName
+            );
+        }, $params);
+    }
+}

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Failure/ConstructorInClassWithParameterWithDefaultValue.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Failure/ConstructorInClassWithParameterWithDefaultValue.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Failure;
+
+final class ConstructorInClassWithParameterWithDefaultValue
+{
+    public function __construct($bar = 9000)
+    {
+    }
+}

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Failure/ConstructorWithWrongCapitalizationInClassWithParameterWithDefaultValue.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Failure/ConstructorWithWrongCapitalizationInClassWithParameterWithDefaultValue.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Failure;
+
+final class ConstructorWithWrongCapitalizationInClassWithParameterWithDefaultValue
+{
+    public function __CoNsTrUcT($bar = 9000)
+    {
+    }
+}

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Failure/constructor-in-anonymous-class-with-parameter-with-default-value.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Failure/constructor-in-anonymous-class-with-parameter-with-default-value.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+
+new class() {
+    public function __construct($bar = 9000)
+    {
+    }
+};

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Failure/constructor-with-wrong-capitalization-in-anonymous-class-with-parameter-with-default-value.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Failure/constructor-with-wrong-capitalization-in-anonymous-class-with-parameter-with-default-value.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+
+new class() {
+    public function __CoNsTrUcT($bar = 9000)
+    {
+    }
+};

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInClassWithParameterWithoutDefaultValue.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInClassWithParameterWithoutDefaultValue.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+
+final class ConstructorInClassWithParameterWithoutDefaultValue
+{
+    public function __construct($bar)
+    {
+    }
+}

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInClassWithoutParameters.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInClassWithoutParameters.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+
+final class ConstructorInClassWithoutParameters
+{
+    public function __construct()
+    {
+    }
+}

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInTraitWithParameterWithDefaultValue.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInTraitWithParameterWithDefaultValue.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+
+trait ConstructorInTraitWithParameterWithDefaultValue
+{
+    public function __construct($bar = 9000)
+    {
+    }
+}

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInTraitWithParameterWithoutDefaultValue.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInTraitWithParameterWithoutDefaultValue.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+
+trait ConstructorInTraitWithParameterWithoutDefaultValue
+{
+    public function __construct($bar)
+    {
+    }
+}

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInTraitWithoutParameters.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInTraitWithoutParameters.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+
+trait ConstructorInTraitWithoutParameters
+{
+    public function __construct()
+    {
+    }
+}

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/MethodInClassWithParameterWithDefaultValue.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/MethodInClassWithParameterWithDefaultValue.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+
+final class MethodInClassWithParameterWithDefaultValue
+{
+    public function foo($bar = 9000)
+    {
+    }
+}

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/MethodInTraitWithParameterWithDefaultValue.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/MethodInTraitWithParameterWithDefaultValue.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+
+trait MethodInTraitWithParameterWithDefaultValue
+{
+    public function foo($bar = 9000)
+    {
+    }
+}

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/constructor-in-anonymous-class-with-parameter-without-default-value.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/constructor-in-anonymous-class-with-parameter-without-default-value.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+
+new class() {
+    public function __construct($bar)
+    {
+    }
+};

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/constructor-in-anonymous-class-without-parameters.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/constructor-in-anonymous-class-without-parameters.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+
+new class() {
+    public function __construct()
+    {
+    }
+};

--- a/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/method-in-anonymous-class-with-parameter-with-default-value.php
+++ b/test/Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/method-in-anonymous-class-with-parameter-with-default-value.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Success;
+
+new class() {
+    public function foo($bar = null)
+    {
+    }
+};

--- a/test/Integration/Methods/NoConstructorParameterWithDefaultValueRuleTest.php
+++ b/test/Integration/Methods/NoConstructorParameterWithDefaultValueRuleTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Integration\Methods;
+
+use Localheinz\PHPStan\Rules\Methods\NoConstructorParameterWithDefaultValueRule;
+use Localheinz\PHPStan\Rules\Test\Fixture;
+use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use PHPStan\Rules\Rule;
+
+/**
+ * @internal
+ */
+final class NoConstructorParameterWithDefaultValueRuleTest extends AbstractTestCase
+{
+    public function providerAnalysisSucceeds(): \Generator
+    {
+        $paths = [
+            'constructor-in-anonymous-class-with-parameter-without-default-value' => __DIR__ . '/../../Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/constructor-in-anonymous-class-with-parameter-without-default-value.php',
+            'constructor-in-anonymous-class-without-parameters' => __DIR__ . '/../../Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/constructor-in-anonymous-class-without-parameters.php',
+            'constructor-in-class-with-parameter-without-default-value' => __DIR__ . '/../../Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInClassWithParameterWithoutDefaultValue.php',
+            'constructor-in-class-without-parameters' => __DIR__ . '/../../Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInClassWithoutParameters.php',
+            // traits are not supported
+            'constructor-in-trait-with-parameter-with-default-value' => __DIR__ . '/../../Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInTraitWithParameterWithDefaultValue.php',
+            'constructor-in-trait-with-parameter-without-default-value' => __DIR__ . '/../../Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInTraitWithParameterWithoutDefaultValue.php',
+            'constructor-in-trait-without-parameters' => __DIR__ . '/../../Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/ConstructorInTraitWithoutParameters.php',
+            // non-constructor-methods
+            'method-in-anonymous-class-with-parameter-with-default-value' => __DIR__ . '/../../Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/method-in-anonymous-class-with-parameter-with-default-value.php',
+            'method-in-class-with-parameter-with-default-value' => __DIR__ . '/../../Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/MethodInClassWithParameterWithDefaultValue.php',
+            'method-in-trait-with-parameter-with-default-value' => __DIR__ . '/../../Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/MethodInTraitWithParameterWithDefaultValue.php',
+        ];
+
+        foreach ($paths as $description => $path) {
+            yield $description => [
+                $path,
+            ];
+        }
+    }
+
+    public function providerAnalysisFails(): \Generator
+    {
+        $paths = [
+            'constructor-in-anonymous-class-with-parameter-with-default-value' => [
+                __DIR__ . '/../../Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Failure/constructor-in-anonymous-class-with-parameter-with-default-value.php',
+                [
+                    'Constructor in anonymous class has parameter $bar with default value.',
+                    8,
+                ],
+            ],
+            'constructor-with-wrong-capitalization-in-anonymous-class-with-parameter-with-default-value' => [
+                __DIR__ . '/../../Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Failure/constructor-with-wrong-capitalization-in-anonymous-class-with-parameter-with-default-value.php',
+                [
+                    'Constructor in anonymous class has parameter $bar with default value.',
+                    8,
+                ],
+            ],
+            'constructor-in-class-with-parameter-with-default-value' => [
+                __DIR__ . '/../../Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Failure/ConstructorInClassWithParameterWithDefaultValue.php',
+                [
+                    \sprintf(
+                        'Constructor in %s has parameter $bar with default value.',
+                        Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Failure\ConstructorInClassWithParameterWithDefaultValue::class
+                    ),
+                    9,
+                ],
+            ],
+            'constructor-with-wrong-capitalization-in-class-with-parameter-with-default-value' => [
+                __DIR__ . '/../../Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Failure/ConstructorWithWrongCapitalizationInClassWithParameterWithDefaultValue.php',
+                [
+                    \sprintf(
+                        'Constructor in %s has parameter $bar with default value.',
+                        Fixture\Methods\NoConstructorParameterWithDefaultValueRule\Failure\ConstructorWithWrongCapitalizationInClassWithParameterWithDefaultValue::class
+                    ),
+                    9,
+                ],
+            ],
+        ];
+
+        foreach ($paths as $description => [$path, $error]) {
+            yield $description => [
+                $path,
+                $error,
+            ];
+        }
+    }
+
+    protected function getRule(): Rule
+    {
+        return new NoConstructorParameterWithDefaultValueRule();
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements `Methods\NoConstructorParameterWithDefaultValueRule`, which reports an error when a constructor in an anonymous class or a class has a parameter with a default value