### PR TITLE
Fix: Adjust README.md in regard to AbstractOrFinalRule and FinalRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ This package provides the following rules for use with [`phpstan/phpstan`](https
 * [`Localheinz\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#methodsnoparameterwithnullabletypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#methodsnoparameterwithnulldefaultvaluerule)
 
-:bulb: If you want to use all of these rules, include [`rules.neon`](rules.neon) in your `phpstan.neon`:
+:bulb: If you want to use the same rules as used by this project, include [`rules.neon`](rules.neon) in your `phpstan.neon`:
 
 ```neon
 includes:
 	- vendor/localheinz/phpstan-rules/rules.neon
 ```
 
-You probably want to use these rules on top of [`phpstan/phpstan-strict-rules`](https://github.com/phpstan/phpstan-strict-rules).
+:bulb: You probably want to use these rules on top of [`phpstan/phpstan-strict-rules`](https://github.com/phpstan/phpstan-strict-rules).
 
 ### `Classes\AbstractOrFinalRule`
 
@@ -65,6 +65,8 @@ services:
 				- Foo\Bar
 ```
 
+:exclamation: This rule conflicts with [`Localheinz\PHPStan\Rules\Classes\FinalRule`](https://github.com/localheinz/phpstan-rules#classesfinalrule), so you probably only want to use one of these.
+
 ### `Classes\FinalRule`
 
 This rule reports an error when a non-anonymous class is not `final`.
@@ -89,6 +91,7 @@ services:
 				- Bar\Foo
 				- Foo\Bar
 ```
+:exclamation: This rule conflicts with [`Localheinz\PHPStan\Rules\Classes\AbstractOrFinalRule`](https://github.com/localheinz/phpstan-rules#classesabstractorfinalrule), so you probably only want to use one of these.
 
 ### `Closures\NoNullableReturnTypeDeclarationRule`
 


### PR DESCRIPTION
This PR

* [x] adjusts `README.md` in regard to using `AbstractOrFinalRule` and `FinalRule`, as well as in regard to `rules.neon`