### PR TITLE
Fix: Configure rules via phpstan.neon instead of --level option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ jobs:
         - composer install
 
       script:
-        - vendor/bin/phpstan analyse --configuration=phpstan.neon --level=max src
+        - vendor/bin/phpstan analyse --configuration=phpstan.neon src
 
     - &TEST
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ infection: vendor
 	vendor/bin/infection --min-covered-msi=95 --min-msi=95
 
 stan: vendor
-	vendor/bin/phpstan analyse --configuration=phpstan.neon --level=max src
+	vendor/bin/phpstan analyse --configuration=phpstan.neon src
 
 test: vendor
 	vendor/bin/phpunit --configuration=test/AutoReview/phpunit.xml

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,7 @@
 includes:
-	- vendor/phpstan/phpstan-strict-rules/rules.neon
 	- rules.neon
+	- vendor/phpstan/phpstan-strict-rules/rules.neon
+	- vendor/phpstan/phpstan/conf/config.levelmax.neon
 
 parameters:
 	ignoreErrors:


### PR DESCRIPTION
This PR

* [x] configures rules via `phpstan.neon` instead of using `--level` option