### PR TITLE
Enhancement: Also run phpstan against tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ jobs:
         - composer install
 
       script:
-        - vendor/bin/phpstan analyse --configuration=phpstan.neon src
+        - vendor/bin/phpstan analyse --configuration=phpstan.neon src test
 
     - &TEST
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ infection: vendor
 	vendor/bin/infection --min-covered-msi=95 --min-msi=95
 
 stan: vendor
-	vendor/bin/phpstan analyse --configuration=phpstan.neon src
+	vendor/bin/phpstan analyse --configuration=phpstan.neon src test
 
 test: vendor
 	vendor/bin/phpunit --configuration=test/AutoReview/phpunit.xml

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,8 @@ includes:
 	- vendor/phpstan/phpstan/conf/config.levelmax.neon
 
 parameters:
+	excludes_analyse:
+		- %currentWorkingDirectory%/test/Fixture/
 	ignoreErrors:
 		- '#Constructor in Localheinz\\PHPStan\\Rules\\Classes\\AbstractOrFinalRule has parameter \$excludedClassNames with default value.#'
 		- '#Constructor in Localheinz\\PHPStan\\Rules\\Classes\\FinalRule has parameter \$excludedClassNames with default value.#'


### PR DESCRIPTION
This PR

* [x] also runs `phpstan` against tests
* [x] excludes fixtures from static analysis