### PR TITLE
Fix: Remove default values from constructor parameters of Classes\FinalRule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,7 +129,7 @@ jobs:
         - xdebug-enable
 
       script:
-        - vendor/bin/infection --min-covered-msi=95 --min-msi=95
+        - vendor/bin/infection --min-covered-msi=98 --min-msi=98
 
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For a full diff see [`0.4.0...master`](https://github.com/localheinz/phpstan-rul
 ### Removed
 
 * Removed `Classes\AbstractOrFinalRule` after merging behaviour into `Classes\FinalRule` ([#51](https://github.com/localheinz/phpstan-rules/pull/51)), by [@localheinz](https://github.com/localheinz)
+* Removed default values from constructor of `Classes\FinalRule` ([#53](https://github.com/localheinz/phpstan-rules/pull/53)), by [@localheinz](https://github.com/localheinz)
 
 ## [`0.4.0`](https://github.com/localheinz/phpstan-rules/releases/tag/0.3.0)
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ cs: vendor
 	vendor/bin/php-cs-fixer fix --config=.php_cs.fixture --diff --verbose
 
 infection: vendor
-	vendor/bin/infection --min-covered-msi=95 --min-msi=95
+	vendor/bin/infection --min-covered-msi=98 --min-msi=98
 
 stan: vendor
 	vendor/bin/phpstan analyse --configuration=phpstan.neon src test

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,3 @@ includes:
 parameters:
 	excludes_analyse:
 		- %currentWorkingDirectory%/test/Fixture/
-	ignoreErrors:
-		- '#Constructor in Localheinz\\PHPStan\\Rules\\Classes\\FinalRule has parameter \$allowAbstractClasses with default value.#'
-		- '#Constructor in Localheinz\\PHPStan\\Rules\\Classes\\FinalRule has parameter \$classesNotRequiredToBeAbstractOrFinal with default value.#'

--- a/src/Classes/FinalRule.php
+++ b/src/Classes/FinalRule.php
@@ -38,7 +38,7 @@ final class FinalRule implements Rule
      * @param bool     $allowAbstractClasses
      * @param string[] $classesNotRequiredToBeAbstractOrFinal
      */
-    public function __construct(bool $allowAbstractClasses = false, array $classesNotRequiredToBeAbstractOrFinal = [])
+    public function __construct(bool $allowAbstractClasses, array $classesNotRequiredToBeAbstractOrFinal)
     {
         $this->allowAbstractClasses = $allowAbstractClasses;
         $this->classesNotRequiredToBeAbstractOrFinal = \array_map(static function (string $classNotRequiredToBeAbstractOrFinal): string {


### PR DESCRIPTION
This PR

* [x] removes default values from constructor parameters of `Classes\FinalRule`

Follows #45.
Follows #51.