### PR TITLE
Enhancement: Implement Classes\NoExtendsRule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,7 +154,7 @@ jobs:
         - mkdir -p $HOME/.build/infection
 
       script:
-        - vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=98 --min-msi=98
+        - vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=96 --min-msi=96
 
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`0.6.0...master`](https://github.com/localheinz/phpstan-rules/compare/0.6.0...master).
 
+### Added
+
+* Added `Classes\NoExtendsRule`, which reports an error when a class extends a class that is not allowed to be extended ([#68](https://github.com/localheinz/phpstan-rules/pull/68)), by [@localheinz](https://github.com/localheinz)
+
 ## [`0.6.0`](https://github.com/localheinz/phpstan-rules/releases/tag/0.6.0)
 
 For a full diff see [`0.5.0...0.6.0`](https://github.com/localheinz/phpstan-rules/compare/0.5.0...0.6.0).

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ cs: vendor
 
 infection: vendor
 	mkdir -p .build/infection
-	vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=98 --min-msi=98
+	vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=96 --min-msi=96
 
 stan: vendor
 	mkdir -p .build/phpstan

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ includes:
 This package provides the following rules for use with [`phpstan/phpstan`](https://github.com/phpstan/phpstan):
 
 * [`Localheinz\PHPStan\Rules\Classes\FinalRule`](https://github.com/localheinz/phpstan-rules#classesfinalrule)
+* [`Localheinz\PHPStan\Rules\Classes\NoExtendsRule`](https://github.com/localheinz/phpstan-rules#classesnoextendsrule)
 * [`Localheinz\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#closuresnonullablereturntypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#closuresnoparameterwithnullabletypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Closures\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#closuresnoparameterwithnulldefaultvaluerule)
@@ -70,6 +71,22 @@ parameters:
 	classesNotRequiredToBeAbstractOrFinal:
 		- Foo\Bar\NeitherAbstractNorFinal
 		- Bar\Baz\NeitherAbstractNorFinal
+```
+
+#### `Classes\NoExtendsRule`
+
+This rule reports an error when a class extends another class.
+
+##### Allowing classes to be extended
+
+If you want to allow some classes to be extended, you can set the `classesAllowedToBeExtended` parameter to a list of class names:
+
+```neon
+parameters:
+	classesAllowedToBeExtended:
+		- Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase
+		- PHPStan\Testing\RuleTestCase
+		- PHPUnit\Framework\TestCase
 ```
 
 ### Closures

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,10 @@ includes:
 	- vendor/phpstan/phpstan/conf/config.levelmax.neon
 
 parameters:
+	classesAllowedToBeExtended:
+		- Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase
+		- PHPStan\Testing\RuleTestCase
+		- PHPUnit\Framework\TestCase
 	excludes_analyse:
 		- %currentWorkingDirectory%/test/Fixture/
 	paths:

--- a/rules.neon
+++ b/rules.neon
@@ -1,5 +1,6 @@
 parameters:
 	allowAbstractClasses: true
+	classesAllowedToBeExtended: []
 	classesNotRequiredToBeAbstractOrFinal: []
 
 rules:
@@ -19,5 +20,11 @@ services:
 		arguments:
 			allowAbstractClasses: %allowAbstractClasses%
 			classesNotRequiredToBeAbstractOrFinal: %classesNotRequiredToBeAbstractOrFinal%
+		tags:
+			- phpstan.rules.rule
+	-
+		class: Localheinz\PHPStan\Rules\Classes\NoExtendsRule
+		arguments:
+			classesAllowedToBeExtended: %classesAllowedToBeExtended%
 		tags:
 			- phpstan.rules.rule

--- a/src/Classes/NoExtendsRule.php
+++ b/src/Classes/NoExtendsRule.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Classes;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+
+final class NoExtendsRule implements Rule
+{
+    /**
+     * @var string[]
+     */
+    private $classesAllowedToBeExtended;
+
+    /**
+     * @param string[] $classesAllowedToBeExtended
+     */
+    public function __construct(array $classesAllowedToBeExtended)
+    {
+        $this->classesAllowedToBeExtended = \array_map(static function (string $classAllowedToBeExtended): string {
+            return $classAllowedToBeExtended;
+        }, $classesAllowedToBeExtended);
+    }
+
+    public function getNodeType(): string
+    {
+        return Node\Stmt\Class_::class;
+    }
+
+    /**
+     * @param Node\Stmt\Class_ $node
+     * @param Scope            $scope
+     *
+     * @return array
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->extends instanceof Node\Name) {
+            return [];
+        }
+
+        $extendedClassName = $node->extends->toString();
+
+        if (\in_array($extendedClassName, $this->classesAllowedToBeExtended, true)) {
+            return [];
+        }
+
+        if (!isset($node->namespacedName)) {
+            return [
+                \sprintf(
+                    'Anonymous class is not allowed to extend "%s".',
+                    $extendedClassName
+                ),
+            ];
+        }
+
+        return [
+            \sprintf(
+                'Class "%s" is not allowed to extend "%s".',
+                $node->namespacedName,
+                $extendedClassName
+            ),
+        ];
+    }
+}

--- a/test/Fixture/Classes/NoExtendsRule/Failure/ClassExtendingOtherClass.php
+++ b/test/Fixture/Classes/NoExtendsRule/Failure/ClassExtendingOtherClass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Failure;
+
+final class ClassExtendingOtherClass extends OtherClass
+{
+}

--- a/test/Fixture/Classes/NoExtendsRule/Failure/OtherClass.php
+++ b/test/Fixture/Classes/NoExtendsRule/Failure/OtherClass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Failure;
+
+class OtherClass
+{
+}

--- a/test/Fixture/Classes/NoExtendsRule/Failure/anonymous-class-extending-other-class.php
+++ b/test/Fixture/Classes/NoExtendsRule/Failure/anonymous-class-extending-other-class.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Failure;
+
+$foo = new class() extends OtherClass {
+    public function __toString(): string
+    {
+        return 'Hmm';
+    }
+};

--- a/test/Fixture/Classes/NoExtendsRule/Success/ExampleClass.php
+++ b/test/Fixture/Classes/NoExtendsRule/Success/ExampleClass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Success;
+
+final class ExampleClass
+{
+}

--- a/test/Fixture/Classes/NoExtendsRule/Success/ExampleInterface.php
+++ b/test/Fixture/Classes/NoExtendsRule/Success/ExampleInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Success;
+
+interface ExampleInterface
+{
+}

--- a/test/Fixture/Classes/NoExtendsRule/Success/InterfaceExtendingOtherInterface.php
+++ b/test/Fixture/Classes/NoExtendsRule/Success/InterfaceExtendingOtherInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Success;
+
+interface InterfaceExtendingOtherInterface extends OtherInterface
+{
+}

--- a/test/Fixture/Classes/NoExtendsRule/Success/OtherInterface.php
+++ b/test/Fixture/Classes/NoExtendsRule/Success/OtherInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Success;
+
+interface OtherInterface
+{
+}

--- a/test/Fixture/Classes/NoExtendsRule/Success/anonymous-class.php
+++ b/test/Fixture/Classes/NoExtendsRule/Success/anonymous-class.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Success;
+
+$foo = new class() {
+    public function __toString(): string
+    {
+        return 'Hmm';
+    }
+};

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Failure/ClassExtendingOtherClass.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Failure/ClassExtendingOtherClass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Failure;
+
+final class ClassExtendingOtherClass extends OtherClass
+{
+}

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Failure/OtherClass.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Failure/OtherClass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Failure;
+
+class OtherClass
+{
+}

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Failure/anonymous-class-extending-other-class.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Failure/anonymous-class-extending-other-class.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Failure;
+
+$foo = new class() extends OtherClass {
+    public function __toString(): string
+    {
+        return 'Hmm';
+    }
+};

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ClassAllowedToBeExtended.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ClassAllowedToBeExtended.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
+
+class ClassAllowedToBeExtended
+{
+}

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ClassExtendingClassAllowedToBeExtended.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ClassExtendingClassAllowedToBeExtended.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
+
+final class ClassExtendingClassAllowedToBeExtended extends ClassAllowedToBeExtended
+{
+}

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ExampleClass.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ExampleClass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
+
+final class ExampleClass
+{
+}

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ExampleInterface.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ExampleInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
+
+interface ExampleInterface
+{
+}

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/InterfaceExtendingOtherInterface.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/InterfaceExtendingOtherInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
+
+interface InterfaceExtendingOtherInterface extends OtherInterface
+{
+}

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/OtherInterface.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/OtherInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
+
+interface OtherInterface
+{
+}

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/anonymous-class-extending-class-allowed-to-be-extended.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/anonymous-class-extending-class-allowed-to-be-extended.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
+
+$foo = new class() extends ClassAllowedToBeExtended {
+    public function __toString(): string
+    {
+        return 'Hmm';
+    }
+};

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/anonymous-class.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/anonymous-class.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
+
+$foo = new class() {
+    public function __toString(): string
+    {
+        return 'Hmm';
+    }
+};

--- a/test/Integration/Classes/NoExtendsRuleTest.php
+++ b/test/Integration/Classes/NoExtendsRuleTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Integration\Classes;
+
+use Localheinz\PHPStan\Rules\Classes\NoExtendsRule;
+use Localheinz\PHPStan\Rules\Test\Fixture;
+use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use PHPStan\Rules\Rule;
+
+/**
+ * @internal
+ */
+final class NoExtendsRuleTest extends AbstractTestCase
+{
+    public function providerAnalysisSucceeds(): \Generator
+    {
+        $paths = [
+            'class' => __DIR__ . '/../../Fixture/Classes/NoExtendsRule/Success/ExampleClass.php',
+            'interface' => __DIR__ . '/../../Fixture/Classes/NoExtendsRule/Success/ExampleInterface.php',
+            'interface-extending-other-interface' => __DIR__ . '/../../Fixture/Classes/NoExtendsRule/Success/InterfaceExtendingOtherInterface.php',
+            'script-with-anonymous-class' => __DIR__ . '/../../Fixture/Classes/NoExtendsRule/Success/anonymous-class.php',
+        ];
+
+        foreach ($paths as $description => $path) {
+            yield $description => [
+                $path,
+            ];
+        }
+    }
+
+    public function providerAnalysisFails(): \Generator
+    {
+        $paths = [
+            'class-extending-other-class' => [
+                __DIR__ . '/../../Fixture/Classes/NoExtendsRule/Failure/ClassExtendingOtherClass.php',
+                [
+                    \sprintf(
+                        'Class "%s" is not allowed to extend "%s".',
+                        Fixture\Classes\NoExtendsRule\Failure\ClassExtendingOtherClass::class,
+                        Fixture\Classes\NoExtendsRule\Failure\OtherClass::class
+                    ),
+                    7,
+                ],
+            ],
+            'script-with-anonymous-class-extending-other-class' => [
+                __DIR__ . '/../../Fixture/Classes/NoExtendsRule/Failure/anonymous-class-extending-other-class.php',
+                [
+                    \sprintf(
+                        'Anonymous class is not allowed to extend "%s".',
+                        Fixture\Classes\NoExtendsRule\Failure\OtherClass::class
+                    ),
+                    7,
+                ],
+            ],
+        ];
+
+        foreach ($paths as $description => [$path, $error]) {
+            yield $description => [
+                $path,
+                $error,
+            ];
+        }
+    }
+
+    protected function getRule(): Rule
+    {
+        return new NoExtendsRule([]);
+    }
+}

--- a/test/Integration/Classes/NoExtendsRuleWithClassesAllowedToBeExtendedTest.php
+++ b/test/Integration/Classes/NoExtendsRuleWithClassesAllowedToBeExtendedTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Integration\Classes;
+
+use Localheinz\PHPStan\Rules\Classes\NoExtendsRule;
+use Localheinz\PHPStan\Rules\Test\Fixture;
+use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use PHPStan\Rules\Rule;
+
+/**
+ * @internal
+ */
+final class NoExtendsRuleWithClassesAllowedToBeExtendedTest extends AbstractTestCase
+{
+    public function providerAnalysisSucceeds(): \Generator
+    {
+        $paths = [
+            'class' => __DIR__ . '/../../Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ExampleClass.php',
+            'class-extending-class-allowed-to-be-extended' => __DIR__ . '/../../Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ClassExtendingClassAllowedToBeExtended.php',
+            'interface' => __DIR__ . '/../../Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ExampleInterface.php',
+            'interface-extending-other-interface' => __DIR__ . '/../../Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/InterfaceExtendingOtherInterface.php',
+            'script-with-anonymous-class' => __DIR__ . '/../../Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/anonymous-class.php',
+            'script-with-anonymous-class-extending-class-allowed-to-be-extended' => __DIR__ . '/../../Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/anonymous-class-extending-class-allowed-to-be-extended.php',
+        ];
+
+        foreach ($paths as $description => $path) {
+            yield $description => [
+                $path,
+            ];
+        }
+    }
+
+    public function providerAnalysisFails(): \Generator
+    {
+        $paths = [
+            'class-extending-other-class' => [
+                __DIR__ . '/../../Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Failure/ClassExtendingOtherClass.php',
+                [
+                    \sprintf(
+                        'Class "%s" is not allowed to extend "%s".',
+                        Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Failure\ClassExtendingOtherClass::class,
+                        Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Failure\OtherClass::class
+                    ),
+                    7,
+                ],
+            ],
+            'script-with-anonymous-class-extending-other-class' => [
+                __DIR__ . '/../../Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Failure/anonymous-class-extending-other-class.php',
+                [
+                    \sprintf(
+                        'Anonymous class is not allowed to extend "%s".',
+                        Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Failure\OtherClass::class
+                    ),
+                    7,
+                ],
+            ],
+        ];
+
+        foreach ($paths as $description => [$path, $error]) {
+            yield $description => [
+                $path,
+                $error,
+            ];
+        }
+    }
+
+    protected function getRule(): Rule
+    {
+        return new NoExtendsRule([
+            Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success\ClassAllowedToBeExtended::class,
+        ]);
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements `Classes\NoExtendsRule` which reports an error when a class extends a class that is not explicitly allowed to be extended