### PR TITLE
Enhancement: Adjust Classes\NoExtendsRule to allow to extend from a set of classes by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.7.0...master`](https://github.com/localheinz/phpstan-rules/compare/0.7.0...master).
+For a full diff see [`0.7.1...master`](https://github.com/localheinz/phpstan-rules/compare/0.7.1...master).
+
+## [`0.7.1`](https://github.com/localheinz/phpstan-rules/releases/tag/0.7.1)
+
+For a full diff see [`0.7.0...0.7.1`](https://github.com/localheinz/phpstan-rules/compare/0.7.0...0.7.1).
+
+### Changed
+
+* Configured `Classes\NoExtendsRule` to allow a set of default classes to be extended ([#73](https://github.com/localheinz/phpstan-rules/pull/73)), by [@localheinz](https://github.com/localheinz)
 
 ## [`0.7.0`](https://github.com/localheinz/phpstan-rules/releases/tag/0.7.0)
 

--- a/README.md
+++ b/README.md
@@ -77,16 +77,21 @@ parameters:
 
 This rule reports an error when a class extends another class.
 
+##### Defaults
+
+By default, this rule allows the following classes to be extended:
+
+* [`PHPUnit\Framework\TestCase`](https://github.com/sebastianbergmann/phpunit/blob/7.5.2/src/Framework/TestCase.php)
+
 ##### Allowing classes to be extended
 
-If you want to allow some classes to be extended, you can set the `classesAllowedToBeExtended` parameter to a list of class names:
+If you want to allow additional classes to be extended, you can set the `classesAllowedToBeExtended` parameter to a list of class names:
 
 ```neon
 parameters:
 	classesAllowedToBeExtended:
 		- Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase
 		- PHPStan\Testing\RuleTestCase
-		- PHPUnit\Framework\TestCase
 ```
 
 ### Closures

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,7 +8,6 @@ parameters:
 	classesAllowedToBeExtended:
 		- Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase
 		- PHPStan\Testing\RuleTestCase
-		- PHPUnit\Framework\TestCase
 	excludes_analyse:
 		- %currentWorkingDirectory%/test/Fixture/
 	paths:

--- a/src/Classes/NoExtendsRule.php
+++ b/src/Classes/NoExtendsRule.php
@@ -22,6 +22,13 @@ final class NoExtendsRule implements Rule
     /**
      * @var string[]
      */
+    private static $defaultClassesAllowedToBeExtended = [
+        'PHPUnit\\Framework\\TestCase',
+    ];
+
+    /**
+     * @var string[]
+     */
     private $classesAllowedToBeExtended;
 
     /**
@@ -29,9 +36,12 @@ final class NoExtendsRule implements Rule
      */
     public function __construct(array $classesAllowedToBeExtended)
     {
-        $this->classesAllowedToBeExtended = \array_map(static function (string $classAllowedToBeExtended): string {
-            return $classAllowedToBeExtended;
-        }, $classesAllowedToBeExtended);
+        $this->classesAllowedToBeExtended = \array_unique(\array_merge(
+            self::$defaultClassesAllowedToBeExtended,
+            \array_map(static function (string $classAllowedToBeExtended): string {
+                return $classAllowedToBeExtended;
+            }, $classesAllowedToBeExtended)
+        ));
     }
 
     public function getNodeType(): string

--- a/test/Fixture/Classes/NoExtendsRule/Success/ClassExtendingPhpUnitFrameworkTestCase.php
+++ b/test/Fixture/Classes/NoExtendsRule/Success/ClassExtendingPhpUnitFrameworkTestCase.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRule\Success;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+final class ClassExtendingPhpUnitFrameworkTestCase extends TestCase
+{
+}

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ClassExtendingPhpUnitFrameworkTestCase.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ClassExtendingPhpUnitFrameworkTestCase.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\NoExtendsRuleWithClassesAllowedToBeExtended\Success;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+final class ClassExtendingPhpUnitFrameworkTestCase extends TestCase
+{
+}

--- a/test/Integration/Classes/NoExtendsRuleTest.php
+++ b/test/Integration/Classes/NoExtendsRuleTest.php
@@ -27,6 +27,7 @@ final class NoExtendsRuleTest extends AbstractTestCase
     {
         $paths = [
             'class' => __DIR__ . '/../../Fixture/Classes/NoExtendsRule/Success/ExampleClass.php',
+            'class-extending-php-unit-framework-test-case' => __DIR__ . '/../../Fixture/Classes/NoExtendsRule/Success/ClassExtendingPhpUnitFrameworkTestCase.php',
             'interface' => __DIR__ . '/../../Fixture/Classes/NoExtendsRule/Success/ExampleInterface.php',
             'interface-extending-other-interface' => __DIR__ . '/../../Fixture/Classes/NoExtendsRule/Success/InterfaceExtendingOtherInterface.php',
             'script-with-anonymous-class' => __DIR__ . '/../../Fixture/Classes/NoExtendsRule/Success/anonymous-class.php',

--- a/test/Integration/Classes/NoExtendsRuleWithClassesAllowedToBeExtendedTest.php
+++ b/test/Integration/Classes/NoExtendsRuleWithClassesAllowedToBeExtendedTest.php
@@ -28,6 +28,7 @@ final class NoExtendsRuleWithClassesAllowedToBeExtendedTest extends AbstractTest
         $paths = [
             'class' => __DIR__ . '/../../Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ExampleClass.php',
             'class-extending-class-allowed-to-be-extended' => __DIR__ . '/../../Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ClassExtendingClassAllowedToBeExtended.php',
+            'class-extending-php-unit-framework-test-case' => __DIR__ . '/../../Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ClassExtendingPhpUnitFrameworkTestCase.php',
             'interface' => __DIR__ . '/../../Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ExampleInterface.php',
             'interface-extending-other-interface' => __DIR__ . '/../../Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/InterfaceExtendingOtherInterface.php',
             'script-with-anonymous-class' => __DIR__ . '/../../Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/anonymous-class.php',


### PR DESCRIPTION
This PR

* [x] adjusts `Classes\NoExtendsRule` to allow to extend from a set of classes by default