### PR TITLE
Remove word 'Test' from testTestsAnalysisSucceeds

### DIFF
--- a/test/Integration/AbstractTestCase.php
+++ b/test/Integration/AbstractTestCase.php
@@ -25,7 +25,7 @@ abstract class AbstractTestCase extends RuleTestCase
      *
      * @param string $path
      */
-    final public function testTestsAnalysisSucceeds(string $path): void
+    final public function testAnalysisSucceeds(string $path): void
     {
         $this->analyse(
             [


### PR DESCRIPTION
Remove word 'Test' from testTestsAnalysisSucceeds to make the method's name similar to testAnalysisFails