### PR TITLE
Fix phpstan/phpstan-deprecation-rules link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ includes:
 :bulb: You probably want to use these rules on top of the rules provided by:
 
 * [`phpstan/phpstan`](https://github.com/phpstan/phpstan)
-* [`phpstan/phpstan-deprecation-rules`](https://github.com/phpstan/phpstan)
+* [`phpstan/phpstan-deprecation-rules`](https://github.com/phpstan/phpstan-deprecation-rules)
 * [`phpstan/phpstan-strict-rules`](https://github.com/phpstan/phpstan-strict-rules)
 
 ## Rules


### PR DESCRIPTION
Link phpstan/phpstan-deprecation-rules to https://github.com/phpstan/phpstan-deprecation-rules instead of https://github.com/phpstan/phpstan
