### PR TITLE
Enhancement: Implement Expressions\NoIssetRule

### DIFF
--- a/.php_cs.fixture
+++ b/.php_cs.fixture
@@ -6,6 +6,7 @@ use Localheinz\PhpCsFixer\Config;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71(''), [
     'lowercase_constants' => false,
+    'lowercase_keywords' => false,
     'magic_method_casing' => false,
     'static_lambda' => false,
 ]);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.7.1...master`](https://github.com/localheinz/phpstan-rules/compare/0.7.1...master).
+For a full diff see [`0.8.0...master`](https://github.com/localheinz/phpstan-rules/compare/0.8.0...master).
+
+## [`0.8.0`](https://github.com/localheinz/phpstan-rules/releases/tag/0.8.0)
+
+For a full diff see [`0.7.1...0.8.0`](https://github.com/localheinz/phpstan-rules/compare/0.7.1...0.8.0).
+
+### Added
+
+* Added `Expressions\NoIssetRule`, which reports an error when the language construct `isset()` is used ([#81](https://github.com/localheinz/phpstan-rules/pull/81)), by [@localheinz](https://github.com/localheinz)
 
 ## [`0.7.1`](https://github.com/localheinz/phpstan-rules/releases/tag/0.7.1)
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ This package provides the following rules for use with [`phpstan/phpstan`](https
 * [`Localheinz\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#closuresnonullablereturntypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#closuresnoparameterwithnullabletypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Closures\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#closuresnoparameterwithnulldefaultvaluerule)
+* [`Localheinz\PHPStan\Rules\Expressions\NoIssetRule`](https://github.com/localheinz/phpstan-rules#expressionsnoissetrule)
 * [`Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#functionsnonullablereturntypedeclarationrule)
-* [`Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#functionsnoparameterwithnulldefaultvaluerule)
 * [`Localheinz\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclaration`](https://github.com/localheinz/phpstan-rules#functionsnoparameterwithnullabletypedeclarationrule)
+* [`Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#functionsnoparameterwithnulldefaultvaluerule)
 * [`Localheinz\PHPStan\Rules\Methods\NoConstructorParameterWithDefaultValueRule`](https://github.com/localheinz/phpstan-rules#methodsnoconstructorparameterwithdefaultvaluerule)
 * [`Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#methodsnonullablereturntypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#methodsnoparameterwithnullabletypedeclarationrule)
@@ -107,6 +108,12 @@ This rule reports an error when a closure has a parameter with a nullable type d
 #### `Closures\NoParameterWithNullDefaultValueRule`
 
 This rule reports an error when a closure has a parameter with `null` as default value.
+
+### Expressions
+
+#### `Expressions\NoIssetRule`
+
+This rule reports an error when the language construct `isset()` is used.
 
 ### Functions
 

--- a/src/Expressions/NoIssetRule.php
+++ b/src/Expressions/NoIssetRule.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Expressions;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+
+final class NoIssetRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Expr\Isset_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        return [
+            'Language construct isset() should not be used.',
+        ];
+    }
+}

--- a/test/Fixture/Expressions/NoIssetRule/Failure/isset-used-with-correct-case.php
+++ b/test/Fixture/Expressions/NoIssetRule/Failure/isset-used-with-correct-case.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoIssetRule\Failure;
+
+if (isset($foo)) {
+    echo 'Hello!';
+}

--- a/test/Fixture/Expressions/NoIssetRule/Failure/isset-used-with-incorrect-case.php
+++ b/test/Fixture/Expressions/NoIssetRule/Failure/isset-used-with-incorrect-case.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoIssetRule\Failure;
+
+if (iSsEt($foo)) {
+    echo 'Hello!';
+}

--- a/test/Fixture/Expressions/NoIssetRule/Success/isset-not-used.php
+++ b/test/Fixture/Expressions/NoIssetRule/Success/isset-not-used.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoIssetRule\Success;
+
+function _isset(): bool
+{
+    return false;
+}
+
+if (_isset()) {
+    echo 'Hello!';
+}

--- a/test/Integration/Expressions/NoIssetRuleTest.php
+++ b/test/Integration/Expressions/NoIssetRuleTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Integration\Expressions;
+
+use Localheinz\PHPStan\Rules\Expressions\NoIssetRule;
+use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use PHPStan\Rules\Rule;
+
+/**
+ * @internal
+ */
+final class NoIssetRuleTest extends AbstractTestCase
+{
+    public function providerAnalysisSucceeds(): \Generator
+    {
+        $paths = [
+            'isset-not-used' => __DIR__ . '/../../Fixture/Expressions/NoIssetRule/Success/isset-not-used.php',
+        ];
+
+        foreach ($paths as $description => $path) {
+            yield $description => [
+                $path,
+            ];
+        }
+    }
+
+    public function providerAnalysisFails(): \Generator
+    {
+        $paths = [
+            'isset-used-with-correct-case' => [
+                __DIR__ . '/../../Fixture/Expressions/NoIssetRule/Failure/isset-used-with-correct-case.php',
+                [
+                    'Language construct isset() should not be used.',
+                    7,
+                ],
+            ],
+            'isset-used-with-incorrect-case' => [
+                __DIR__ . '/../../Fixture/Expressions/NoIssetRule/Failure/isset-used-with-incorrect-case.php',
+                [
+                    'Language construct isset() should not be used.',
+                    7,
+                ],
+            ],
+        ];
+
+        foreach ($paths as $description => [$path, $error]) {
+            yield $description => [
+                $path,
+                $error,
+            ];
+        }
+    }
+
+    protected function getRule(): Rule
+    {
+        return new NoIssetRule();
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements an `Expressions\NoIssetRule` which reports an error when the language construct `isset()` is used