### PR TITLE
Enhancement: Update localheinz/php-cs-fixer-config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "require-dev": {
     "infection/infection": "~0.12.0",
     "localheinz/composer-normalize": "^1.1.1",
-    "localheinz/php-cs-fixer-config": "~1.19.0",
+    "localheinz/php-cs-fixer-config": "~1.20.0",
     "localheinz/test-util": "~0.7.0",
     "phpstan/phpstan-deprecation-rules": "~0.10.2 || ~0.11.0",
     "phpstan/phpstan-strict-rules": "~0.10.1 || ~0.11.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b06b91efc6ead32962c008288d0b8f51",
+    "content-hash": "a291af9cd377f042d4f50a538c4e190e",
     "packages": [
         {
             "name": "composer/xdebug-handler",
-            "version": "1.3.1",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "dc523135366eb68f22268d069ea7749486458562"
+                "reference": "d17708133b6c276d6e42ef887a877866b909d892"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/dc523135366eb68f22268d069ea7749486458562",
-                "reference": "dc523135366eb68f22268d069ea7749486458562",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/d17708133b6c276d6e42ef887a877866b909d892",
+                "reference": "d17708133b6c276d6e42ef887a877866b909d892",
                 "shasum": ""
             },
             "require": {
@@ -48,7 +48,7 @@
                 "Xdebug",
                 "performance"
             ],
-            "time": "2018-11-29T10:59:02+00:00"
+            "time": "2019-01-28T20:25:53+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",
@@ -846,16 +846,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v4.2.2",
+            "version": "v4.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "b0a03c1bb0fcbe288629956cf2f1dd3f1dc97522"
+                "reference": "e2840bb38bddad7a0feaf85931e38fdcffdb2f81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/b0a03c1bb0fcbe288629956cf2f1dd3f1dc97522",
-                "reference": "b0a03c1bb0fcbe288629956cf2f1dd3f1dc97522",
+                "url": "https://api.github.com/repos/symfony/console/zipball/e2840bb38bddad7a0feaf85931e38fdcffdb2f81",
+                "reference": "e2840bb38bddad7a0feaf85931e38fdcffdb2f81",
                 "shasum": ""
             },
             "require": {
@@ -867,6 +867,9 @@
                 "symfony/dependency-injection": "<3.4",
                 "symfony/process": "<3.3"
             },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
             "require-dev": {
                 "psr/log": "~1.0",
                 "symfony/config": "~3.4|~4.0",
@@ -876,7 +879,7 @@
                 "symfony/process": "~3.4|~4.0"
             },
             "suggest": {
-                "psr/log-implementation": "For using the console logger",
+                "psr/log": "For using the console logger",
                 "symfony/event-dispatcher": "",
                 "symfony/lock": "",
                 "symfony/process": ""
@@ -911,7 +914,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-04T15:13:53+00:00"
+            "time": "2019-04-08T14:23:48+00:00"
         },
         {
             "name": "symfony/contracts",
@@ -983,16 +986,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v4.2.2",
+            "version": "v4.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "9094d69e8c6ee3fe186a0ec5a4f1401e506071ce"
+                "reference": "e45135658bd6c14b61850bf131c4f09a55133f69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/9094d69e8c6ee3fe186a0ec5a4f1401e506071ce",
-                "reference": "9094d69e8c6ee3fe186a0ec5a4f1401e506071ce",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e45135658bd6c14b61850bf131c4f09a55133f69",
+                "reference": "e45135658bd6c14b61850bf131c4f09a55133f69",
                 "shasum": ""
             },
             "require": {
@@ -1028,20 +1031,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-03T09:07:35+00:00"
+            "time": "2019-04-06T13:51:08+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494"
+                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/c79c051f5b3a46be09205c73b80b346e4153e494",
-                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fe5e94c604826c35a32fa832f35bd036b6799609",
+                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609",
                 "shasum": ""
             },
             "require": {
@@ -1053,7 +1056,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -1087,7 +1090,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-09-21T13:07:52+00:00"
+            "time": "2019-02-06T07:57:58+00:00"
         }
     ],
     "packages-dev": [
@@ -1149,16 +1152,16 @@
         },
         {
             "name": "composer/semver",
-            "version": "1.4.2",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573"
+                "reference": "46d9139568ccb8d9e7cdd4539cab7347568a5e2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/c7cb9a2095a074d131b65a8a0cd294479d785573",
-                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573",
+                "url": "https://api.github.com/repos/composer/semver/zipball/46d9139568ccb8d9e7cdd4539cab7347568a5e2e",
+                "reference": "46d9139568ccb8d9e7cdd4539cab7347568a5e2e",
                 "shasum": ""
             },
             "require": {
@@ -1207,20 +1210,20 @@
                 "validation",
                 "versioning"
             ],
-            "time": "2016-08-30T16:08:34+00:00"
+            "time": "2019-03-19T17:25:45+00:00"
         },
         {
             "name": "doctrine/annotations",
-            "version": "v1.6.0",
+            "version": "v1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5"
+                "reference": "53120e0eb10355388d6ccbe462f1fea34ddadb24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
-                "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/53120e0eb10355388d6ccbe462f1fea34ddadb24",
+                "reference": "53120e0eb10355388d6ccbe462f1fea34ddadb24",
                 "shasum": ""
             },
             "require": {
@@ -1275,7 +1278,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2017-12-06T07:11:42+00:00"
+            "time": "2019-03-25T19:12:02+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -1387,16 +1390,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.14.0",
+            "version": "v2.14.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "b788ea0af899cedc8114dca7db119c93b6685da2"
+                "reference": "ff401e58261ffc5934a58f795b3f95b355e276cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/b788ea0af899cedc8114dca7db119c93b6685da2",
-                "reference": "b788ea0af899cedc8114dca7db119c93b6685da2",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/ff401e58261ffc5934a58f795b3f95b355e276cb",
+                "reference": "ff401e58261ffc5934a58f795b3f95b355e276cb",
                 "shasum": ""
             },
             "require": {
@@ -1416,9 +1419,6 @@
                 "symfony/polyfill-php72": "^1.4",
                 "symfony/process": "^3.0 || ^4.0",
                 "symfony/stopwatch": "^3.0 || ^4.0"
-            },
-            "conflict": {
-                "hhvm": "*"
             },
             "require-dev": {
                 "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
@@ -1443,11 +1443,6 @@
                 "php-cs-fixer"
             ],
             "type": "application",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.14-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "PhpCsFixer\\": "src/"
@@ -1479,7 +1474,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2019-01-04T18:29:47+00:00"
+            "time": "2019-02-17T17:44:13+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -1949,20 +1944,20 @@
         },
         {
             "name": "localheinz/php-cs-fixer-config",
-            "version": "1.19.0",
+            "version": "1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/localheinz/php-cs-fixer-config.git",
-                "reference": "6237bcf8636243bc2d1a995f67c49ac58cb76188"
+                "reference": "17150988bef165e89525bde8a62bb21883201dd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localheinz/php-cs-fixer-config/zipball/6237bcf8636243bc2d1a995f67c49ac58cb76188",
-                "reference": "6237bcf8636243bc2d1a995f67c49ac58cb76188",
+                "url": "https://api.github.com/repos/localheinz/php-cs-fixer-config/zipball/17150988bef165e89525bde8a62bb21883201dd9",
+                "reference": "17150988bef165e89525bde8a62bb21883201dd9",
                 "shasum": ""
             },
             "require": {
-                "friendsofphp/php-cs-fixer": "^2.14.0",
+                "friendsofphp/php-cs-fixer": "~2.14.2",
                 "php": "^5.6 || ^7.0"
             },
             "require-dev": {
@@ -1986,7 +1981,7 @@
             ],
             "description": "Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer.",
             "homepage": "https://github.com/localheinz/php-cs-fixer-config",
-            "time": "2019-01-04T23:09:58+00:00"
+            "time": "2019-03-31T12:40:54+00:00"
         },
         {
             "name": "localheinz/test-util",
@@ -3715,16 +3710,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v4.2.1",
+            "version": "v4.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "921f49c3158a276d27c0d770a5a347a3b718b328"
+                "reference": "fbce53cd74ac509cbe74b6f227622650ab759b02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/921f49c3158a276d27c0d770a5a347a3b718b328",
-                "reference": "921f49c3158a276d27c0d770a5a347a3b718b328",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/fbce53cd74ac509cbe74b6f227622650ab759b02",
+                "reference": "fbce53cd74ac509cbe74b6f227622650ab759b02",
                 "shasum": ""
             },
             "require": {
@@ -3775,20 +3770,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2018-12-01T08:52:38+00:00"
+            "time": "2019-04-06T13:51:08+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.2.2",
+            "version": "v4.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "c2ffd9a93f2d6c5be2f68a0aa7953cc229f871f8"
+                "reference": "e16b9e471703b2c60b95f14d31c1239f68f11601"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/c2ffd9a93f2d6c5be2f68a0aa7953cc229f871f8",
-                "reference": "c2ffd9a93f2d6c5be2f68a0aa7953cc229f871f8",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e16b9e471703b2c60b95f14d31c1239f68f11601",
+                "reference": "e16b9e471703b2c60b95f14d31c1239f68f11601",
                 "shasum": ""
             },
             "require": {
@@ -3825,20 +3820,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-03T09:07:35+00:00"
+            "time": "2019-02-07T11:40:08+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v4.2.1",
+            "version": "v4.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "a9c38e8a3da2c03b3e71fdffa6efb0bda51390ba"
+                "reference": "fd4a5f27b7cd085b489247b9890ebca9f3e10044"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/a9c38e8a3da2c03b3e71fdffa6efb0bda51390ba",
-                "reference": "a9c38e8a3da2c03b3e71fdffa6efb0bda51390ba",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/fd4a5f27b7cd085b489247b9890ebca9f3e10044",
+                "reference": "fd4a5f27b7cd085b489247b9890ebca9f3e10044",
                 "shasum": ""
             },
             "require": {
@@ -3879,20 +3874,20 @@
                 "configuration",
                 "options"
             ],
-            "time": "2018-11-11T19:52:12+00:00"
+            "time": "2019-04-10T16:20:36+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
+                "reference": "82ebae02209c21113908c229e9883c419720738a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
+                "reference": "82ebae02209c21113908c229e9883c419720738a",
                 "shasum": ""
             },
             "require": {
@@ -3904,7 +3899,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -3937,20 +3932,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "6b88000cdd431cd2e940caa2cb569201f3f84224"
+                "reference": "bc4858fb611bda58719124ca079baff854149c89"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/6b88000cdd431cd2e940caa2cb569201f3f84224",
-                "reference": "6b88000cdd431cd2e940caa2cb569201f3f84224",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/bc4858fb611bda58719124ca079baff854149c89",
+                "reference": "bc4858fb611bda58719124ca079baff854149c89",
                 "shasum": ""
             },
             "require": {
@@ -3960,7 +3955,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -3996,20 +3991,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-09-21T06:26:08+00:00"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "9050816e2ca34a8e916c3a0ae8b9c2fccf68b631"
+                "reference": "ab50dcf166d5f577978419edd37aa2bb8eabce0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/9050816e2ca34a8e916c3a0ae8b9c2fccf68b631",
-                "reference": "9050816e2ca34a8e916c3a0ae8b9c2fccf68b631",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/ab50dcf166d5f577978419edd37aa2bb8eabce0c",
+                "reference": "ab50dcf166d5f577978419edd37aa2bb8eabce0c",
                 "shasum": ""
             },
             "require": {
@@ -4018,7 +4013,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -4051,20 +4046,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-09-21T13:07:52+00:00"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v4.2.2",
+            "version": "v4.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "ea043ab5d8ed13b467a9087d81cb876aee7f689a"
+                "reference": "8cf39fb4ccff793340c258ee7760fd40bfe745fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/ea043ab5d8ed13b467a9087d81cb876aee7f689a",
-                "reference": "ea043ab5d8ed13b467a9087d81cb876aee7f689a",
+                "url": "https://api.github.com/repos/symfony/process/zipball/8cf39fb4ccff793340c258ee7760fd40bfe745fe",
+                "reference": "8cf39fb4ccff793340c258ee7760fd40bfe745fe",
                 "shasum": ""
             },
             "require": {
@@ -4100,20 +4095,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-03T14:48:52+00:00"
+            "time": "2019-04-10T16:20:36+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v4.2.1",
+            "version": "v4.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "ec076716412274e51f8a7ea675d9515e5c311123"
+                "reference": "b1a5f646d56a3290230dbc8edf2a0d62cda23f67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/ec076716412274e51f8a7ea675d9515e5c311123",
-                "reference": "ec076716412274e51f8a7ea675d9515e5c311123",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/b1a5f646d56a3290230dbc8edf2a0d62cda23f67",
+                "reference": "b1a5f646d56a3290230dbc8edf2a0d62cda23f67",
                 "shasum": ""
             },
             "require": {
@@ -4150,7 +4145,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-11T19:52:12+00:00"
+            "time": "2019-01-16T20:31:39+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 final class SrcCodeTest extends Framework\TestCase

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class SrcCodeTest extends Framework\TestCase
 {

--- a/test/AutoReview/TestCodeTest.php
+++ b/test/AutoReview/TestCodeTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class TestCodeTest extends Framework\TestCase
 {

--- a/test/AutoReview/TestCodeTest.php
+++ b/test/AutoReview/TestCodeTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 final class TestCodeTest extends Framework\TestCase

--- a/test/Fixture/Classes/NoExtendsRule/Success/ClassExtendingPhpUnitFrameworkTestCase.php
+++ b/test/Fixture/Classes/NoExtendsRule/Success/ClassExtendingPhpUnitFrameworkTestCase.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class ClassExtendingPhpUnitFrameworkTestCase extends TestCase
 {

--- a/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ClassExtendingPhpUnitFrameworkTestCase.php
+++ b/test/Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ClassExtendingPhpUnitFrameworkTestCase.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class ClassExtendingPhpUnitFrameworkTestCase extends TestCase
 {

--- a/test/Integration/Classes/FinalRuleTest.php
+++ b/test/Integration/Classes/FinalRuleTest.php
@@ -20,6 +20,7 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class FinalRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Classes/FinalRuleTest.php
+++ b/test/Integration/Classes/FinalRuleTest.php
@@ -20,7 +20,8 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
- * @coversNothing
+ *
+ * @covers \Localheinz\PHPStan\Rules\Classes\FinalRule
  */
 final class FinalRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Classes/FinalRuleWithAbstractClassesAllowedTest.php
+++ b/test/Integration/Classes/FinalRuleWithAbstractClassesAllowedTest.php
@@ -20,6 +20,7 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class FinalRuleWithAbstractClassesAllowedTest extends AbstractTestCase
 {

--- a/test/Integration/Classes/FinalRuleWithAbstractClassesAllowedTest.php
+++ b/test/Integration/Classes/FinalRuleWithAbstractClassesAllowedTest.php
@@ -20,7 +20,8 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
- * @coversNothing
+ *
+ * @covers \Localheinz\PHPStan\Rules\Classes\FinalRule
  */
 final class FinalRuleWithAbstractClassesAllowedTest extends AbstractTestCase
 {

--- a/test/Integration/Classes/FinalRuleWithExcludedClassNamesTest.php
+++ b/test/Integration/Classes/FinalRuleWithExcludedClassNamesTest.php
@@ -20,7 +20,8 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
- * @coversNothing
+ *
+ * @covers \Localheinz\PHPStan\Rules\Classes\FinalRule
  */
 final class FinalRuleWithExcludedClassNamesTest extends AbstractTestCase
 {

--- a/test/Integration/Classes/FinalRuleWithExcludedClassNamesTest.php
+++ b/test/Integration/Classes/FinalRuleWithExcludedClassNamesTest.php
@@ -20,6 +20,7 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class FinalRuleWithExcludedClassNamesTest extends AbstractTestCase
 {

--- a/test/Integration/Classes/NoExtendsRuleTest.php
+++ b/test/Integration/Classes/NoExtendsRuleTest.php
@@ -20,6 +20,7 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class NoExtendsRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Classes/NoExtendsRuleTest.php
+++ b/test/Integration/Classes/NoExtendsRuleTest.php
@@ -20,7 +20,8 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
- * @coversNothing
+ *
+ * @covers \Localheinz\PHPStan\Rules\Classes\NoExtendsRule
  */
 final class NoExtendsRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Classes/NoExtendsRuleWithClassesAllowedToBeExtendedTest.php
+++ b/test/Integration/Classes/NoExtendsRuleWithClassesAllowedToBeExtendedTest.php
@@ -20,6 +20,7 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class NoExtendsRuleWithClassesAllowedToBeExtendedTest extends AbstractTestCase
 {

--- a/test/Integration/Classes/NoExtendsRuleWithClassesAllowedToBeExtendedTest.php
+++ b/test/Integration/Classes/NoExtendsRuleWithClassesAllowedToBeExtendedTest.php
@@ -20,7 +20,8 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
- * @coversNothing
+ *
+ * @covers \Localheinz\PHPStan\Rules\Classes\NoExtendsRule
  */
 final class NoExtendsRuleWithClassesAllowedToBeExtendedTest extends AbstractTestCase
 {

--- a/test/Integration/Closures/NoNullableReturnTypeDeclarationRuleTest.php
+++ b/test/Integration/Closures/NoNullableReturnTypeDeclarationRuleTest.php
@@ -19,6 +19,7 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class NoNullableReturnTypeDeclarationRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Closures/NoNullableReturnTypeDeclarationRuleTest.php
+++ b/test/Integration/Closures/NoNullableReturnTypeDeclarationRuleTest.php
@@ -19,7 +19,8 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
- * @coversNothing
+ *
+ * @covers \Localheinz\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule
  */
 final class NoNullableReturnTypeDeclarationRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Closures/NoParameterWithNullDefaultValueRuleTest.php
+++ b/test/Integration/Closures/NoParameterWithNullDefaultValueRuleTest.php
@@ -19,6 +19,7 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class NoParameterWithNullDefaultValueRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Closures/NoParameterWithNullDefaultValueRuleTest.php
+++ b/test/Integration/Closures/NoParameterWithNullDefaultValueRuleTest.php
@@ -19,7 +19,8 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
- * @coversNothing
+ *
+ * @covers \Localheinz\PHPStan\Rules\Closures\NoParameterWithNullDefaultValueRule
  */
 final class NoParameterWithNullDefaultValueRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Closures/NoParameterWithNullableTypeDeclarationRuleTest.php
+++ b/test/Integration/Closures/NoParameterWithNullableTypeDeclarationRuleTest.php
@@ -19,6 +19,7 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class NoParameterWithNullableTypeDeclarationRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Closures/NoParameterWithNullableTypeDeclarationRuleTest.php
+++ b/test/Integration/Closures/NoParameterWithNullableTypeDeclarationRuleTest.php
@@ -19,7 +19,8 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
- * @coversNothing
+ *
+ * @covers \Localheinz\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule
  */
 final class NoParameterWithNullableTypeDeclarationRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Expressions/NoIssetRuleTest.php
+++ b/test/Integration/Expressions/NoIssetRuleTest.php
@@ -19,6 +19,8 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
+ *
+ * @covers \Localheinz\PHPStan\Rules\Expressions\NoIssetRule
  */
 final class NoIssetRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Functions/NoNullableReturnTypeDeclarationRuleTest.php
+++ b/test/Integration/Functions/NoNullableReturnTypeDeclarationRuleTest.php
@@ -19,6 +19,7 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class NoNullableReturnTypeDeclarationRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Functions/NoNullableReturnTypeDeclarationRuleTest.php
+++ b/test/Integration/Functions/NoNullableReturnTypeDeclarationRuleTest.php
@@ -19,7 +19,8 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
- * @coversNothing
+ *
+ * @covers \Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule
  */
 final class NoNullableReturnTypeDeclarationRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Functions/NoParameterWithNullDefaultValueRuleTest.php
+++ b/test/Integration/Functions/NoParameterWithNullDefaultValueRuleTest.php
@@ -19,7 +19,8 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
- * @coversNothing
+ *
+ * @covers \Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule
  */
 final class NoParameterWithNullDefaultValueRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Functions/NoParameterWithNullDefaultValueRuleTest.php
+++ b/test/Integration/Functions/NoParameterWithNullDefaultValueRuleTest.php
@@ -19,6 +19,7 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class NoParameterWithNullDefaultValueRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Functions/NoParameterWithNullableTypeDeclarationRuleTest.php
+++ b/test/Integration/Functions/NoParameterWithNullableTypeDeclarationRuleTest.php
@@ -19,6 +19,7 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class NoParameterWithNullableTypeDeclarationRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Functions/NoParameterWithNullableTypeDeclarationRuleTest.php
+++ b/test/Integration/Functions/NoParameterWithNullableTypeDeclarationRuleTest.php
@@ -19,7 +19,8 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
- * @coversNothing
+ *
+ * @covers \Localheinz\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclarationRule
  */
 final class NoParameterWithNullableTypeDeclarationRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Methods/NoConstructorParameterWithDefaultValueRuleTest.php
+++ b/test/Integration/Methods/NoConstructorParameterWithDefaultValueRuleTest.php
@@ -20,7 +20,8 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
- * @coversNothing
+ *
+ * @covers \Localheinz\PHPStan\Rules\Methods\NoConstructorParameterWithDefaultValueRule
  */
 final class NoConstructorParameterWithDefaultValueRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Methods/NoConstructorParameterWithDefaultValueRuleTest.php
+++ b/test/Integration/Methods/NoConstructorParameterWithDefaultValueRuleTest.php
@@ -20,6 +20,7 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class NoConstructorParameterWithDefaultValueRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Methods/NoNullableReturnTypeDeclarationRuleTest.php
+++ b/test/Integration/Methods/NoNullableReturnTypeDeclarationRuleTest.php
@@ -20,7 +20,8 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
- * @coversNothing
+ *
+ * @covers \Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule
  */
 final class NoNullableReturnTypeDeclarationRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Methods/NoNullableReturnTypeDeclarationRuleTest.php
+++ b/test/Integration/Methods/NoNullableReturnTypeDeclarationRuleTest.php
@@ -20,6 +20,7 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class NoNullableReturnTypeDeclarationRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Methods/NoParameterWithNullDefaultValueRuleTest.php
+++ b/test/Integration/Methods/NoParameterWithNullDefaultValueRuleTest.php
@@ -20,6 +20,7 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class NoParameterWithNullDefaultValueRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Methods/NoParameterWithNullDefaultValueRuleTest.php
+++ b/test/Integration/Methods/NoParameterWithNullDefaultValueRuleTest.php
@@ -20,7 +20,8 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
- * @coversNothing
+ *
+ * @covers \Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule
  */
 final class NoParameterWithNullDefaultValueRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Methods/NoParameterWithNullableTypeDeclarationRuleTest.php
+++ b/test/Integration/Methods/NoParameterWithNullableTypeDeclarationRuleTest.php
@@ -20,7 +20,8 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
- * @coversNothing
+ *
+ * @covers \Localheinz\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule
  */
 final class NoParameterWithNullableTypeDeclarationRuleTest extends AbstractTestCase
 {

--- a/test/Integration/Methods/NoParameterWithNullableTypeDeclarationRuleTest.php
+++ b/test/Integration/Methods/NoParameterWithNullableTypeDeclarationRuleTest.php
@@ -20,6 +20,7 @@ use PHPStan\Rules\Rule;
 
 /**
  * @internal
+ * @coversNothing
  */
 final class NoParameterWithNullableTypeDeclarationRuleTest extends AbstractTestCase
 {


### PR DESCRIPTION
This PR

* [x] updates `localheinz/php-cs-fixer-config`
* [x] runs `make cs`
* [x] replaces `@coversNothing` annotations where applicable

💁‍♂ For reference, see https://github.com/localheinz/php-cs-fixer-config/compare/1.19.0...1.20.0.