### PR TITLE
Fix: Enable Expressions\NoIssetRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.8.0...master`](https://github.com/localheinz/phpstan-rules/compare/0.8.0...master).
+For a full diff see [`0.8.1...master`](https://github.com/localheinz/phpstan-rules/compare/0.8.1...master).
+
+## [`0.8.1`](https://github.com/localheinz/phpstan-rules/releases/tag/0.8.1)
+
+For a full diff see [`0.8.0...0.8.1`](https://github.com/localheinz/phpstan-rules/compare/0.8.0...0.8.1).
+
+### Fixed
+
+* Actually enable `Expressions\NoIssetRule` ([#83](https://github.com/localheinz/phpstan-rules/pull/83)), by [@localheinz](https://github.com/localheinz)
 
 ## [`0.8.0`](https://github.com/localheinz/phpstan-rules/releases/tag/0.8.0)
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,8 @@ parameters:
 		- PHPStan\Testing\RuleTestCase
 	excludes_analyse:
 		- %currentWorkingDirectory%/test/Fixture/
+	ignoreErrors:
+		- '#Language construct isset\(\) should not be used.#'
 	paths:
 		- src
 		- test

--- a/rules.neon
+++ b/rules.neon
@@ -6,6 +6,7 @@ parameters:
 rules:
 	- Localheinz\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule
+	- Localheinz\PHPStan\Rules\Expressions\NoIssetRule
 	- Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule


### PR DESCRIPTION
This PR

* [x] enables `Expressions\NoIssetRule` 
* [x] ignores errors related to 3rd-party code 