### PR TITLE
Enhancement: Adjust Classes\FinalRule to ignore Doctrine entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.8.1...master`](https://github.com/localheinz/phpstan-rules/compare/0.8.1...master).
+For a full diff see [`0.9.0...master`](https://github.com/localheinz/phpstan-rules/compare/0.9.0...master).
+
+## [`0.9.0`](https://github.com/localheinz/phpstan-rules/releases/tag/0.9.0)
+
+For a full diff see [`0.8.1...0.9.0`](https://github.com/localheinz/phpstan-rules/compare/0.8.1...0.9.0).
+
+### Changed
+
+* Adjusted `Classes\FinalRule` to ignore Doctrine entities when they are annotated ([#84](https://github.com/localheinz/phpstan-rules/pull/84)), by [@localheinz](https://github.com/localheinz)
 
 ## [`0.8.1`](https://github.com/localheinz/phpstan-rules/releases/tag/0.8.1)
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ This package provides the following rules for use with [`phpstan/phpstan`](https
 
 This rule reports an error when a non-anonymous class is not `final`.
 
+:bulb: Doctrine entities are currently ignored when they are annotated with `@ORM\Entity` or `@Entity`.
+
 ##### Disallowing `abstract` classes
 
 By default, this rule allows to declare `abstract` classes. If you want to disallow declaring `abstract` classes, you can set the `allowAbstractClasses` parameter to `false`:
@@ -185,3 +187,7 @@ Please have a look at [`CODE_OF_CONDUCT.md`](.github/CODE_OF_CONDUCT.md).
 ## License
 
 This package is licensed using the MIT License.
+
+## Credits
+
+The method [`FinalRule::isWhitelistedClass()`](src/Classes/FinalRule.php) is inspired by the work on [`PhpCsFixer\Fixer\ClassNotation\FinalClassFixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/2.15/src/Fixer/ClassNotation/FinalClassFixer.php) and [`PhpCsFixer\Fixer\ClassNotation\FinalInternalClassFixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/2.15/src/Fixer/ClassNotation/FinalInternalClassFixer.php), contributed by [Dariusz Rumiński](https://github.com/keradus), [Filippo Tessarotto](https://github.com/Slamdunk), and [Spacepossum](https://github.com/SpacePossum) for [`friendsofphp/php-cs-fixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer) (originally licensed under MIT).

--- a/test/Fixture/Classes/FinalRule/Failure/NonFinalClassWithoutEntityAnnotationInInlineDocBlock.php
+++ b/test/Fixture/Classes/FinalRule/Failure/NonFinalClassWithoutEntityAnnotationInInlineDocBlock.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Failure;
+
+/** @eNtItY */
+class NonFinalClassWithoutEntityAnnotationInInlineDocBlock
+{
+}

--- a/test/Fixture/Classes/FinalRule/Failure/NonFinalClassWithoutEntityAnnotationInMultilineDocBlock.php
+++ b/test/Fixture/Classes/FinalRule/Failure/NonFinalClassWithoutEntityAnnotationInMultilineDocBlock.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Failure;
+
+/**
+ * @Table(name="hmm")
+ * @eNtItY
+ */
+class NonFinalClassWithoutEntityAnnotationInMultilineDocBlock
+{
+}

--- a/test/Fixture/Classes/FinalRule/Failure/NonFinalClassWithoutOrmEntityAnnotationInInlineDocBlock.php
+++ b/test/Fixture/Classes/FinalRule/Failure/NonFinalClassWithoutOrmEntityAnnotationInInlineDocBlock.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Failure;
+
+/** @OrM\eNtItY */
+class NonFinalClassWithoutOrmEntityAnnotationInInlineDocBlock
+{
+}

--- a/test/Fixture/Classes/FinalRule/Failure/NonFinalClassWithoutOrmEntityAnnotationInMultilineDocBlock.php
+++ b/test/Fixture/Classes/FinalRule/Failure/NonFinalClassWithoutOrmEntityAnnotationInMultilineDocBlock.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Failure;
+
+/**
+ * @ORM\Table(name="hmm")
+ * @OrM\eNtItY
+ */
+class NonFinalClassWithoutOrmEntityAnnotationInMultilineDocBlock
+{
+}

--- a/test/Fixture/Classes/FinalRule/Success/NonFinalClassWithEntityAnnotationInInlineDocBlock.php
+++ b/test/Fixture/Classes/FinalRule/Success/NonFinalClassWithEntityAnnotationInInlineDocBlock.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
+
+/** @Entity */
+class NonFinalClassWithEntityAnnotationInInlineDocBlock
+{
+}

--- a/test/Fixture/Classes/FinalRule/Success/NonFinalClassWithEntityAnnotationInMultilineDocBlock.php
+++ b/test/Fixture/Classes/FinalRule/Success/NonFinalClassWithEntityAnnotationInMultilineDocBlock.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
+
+/**
+ * @Table(name="hmm")
+ * @Entity
+ */
+class NonFinalClassWithEntityAnnotationInMultilineDocBlock
+{
+}

--- a/test/Fixture/Classes/FinalRule/Success/NonFinalClassWithOrmEntityAnnotationInInlineDocBlock.php
+++ b/test/Fixture/Classes/FinalRule/Success/NonFinalClassWithOrmEntityAnnotationInInlineDocBlock.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
+
+/** @ORM\Entity */
+class NonFinalClassWithOrmEntityAnnotationInInlineDocBlock
+{
+}

--- a/test/Fixture/Classes/FinalRule/Success/NonFinalClassWithOrmEntityAnnotationInMultilineDocBlock.php
+++ b/test/Fixture/Classes/FinalRule/Success/NonFinalClassWithOrmEntityAnnotationInMultilineDocBlock.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Classes\FinalRule\Success;
+
+/**
+ * @ORM\Table(name="hmm")
+ * @ORM\Entity
+ */
+class NonFinalClassWithOrmEntityAnnotationInMultilineDocBlock
+{
+}

--- a/test/Integration/Classes/FinalRuleTest.php
+++ b/test/Integration/Classes/FinalRuleTest.php
@@ -31,6 +31,10 @@ final class FinalRuleTest extends AbstractTestCase
             'final-class' => __DIR__ . '/../../Fixture/Classes/FinalRule/Success/FinalClass.php',
             'final-class-with-anonymous-class' => __DIR__ . '/../../Fixture/Classes/FinalRule/Success/FinalClassWithAnonymousClass.php',
             'interface' => __DIR__ . '/../../Fixture/Classes/FinalRule/Success/ExampleInterface.php',
+            'non-final-class-with-entity-annotation-in-inline-doc-block' => __DIR__ . '/../../Fixture/Classes/FinalRule/Success/NonFinalClassWithEntityAnnotationInInlineDocBlock.php',
+            'non-final-class-with-entity-annotation-in-multi-line-doc-block' => __DIR__ . '/../../Fixture/Classes/FinalRule/Success/NonFinalClassWithEntityAnnotationInMultilineDocBlock.php',
+            'non-final-class-with-orm-entity-annotation-in-inline-doc-block' => __DIR__ . '/../../Fixture/Classes/FinalRule/Success/NonFinalClassWithOrmEntityAnnotationInInlineDocBlock.php',
+            'non-final-class-with-orm-entity-annotation-in-multi-line-doc-block' => __DIR__ . '/../../Fixture/Classes/FinalRule/Success/NonFinalClassWithOrmEntityAnnotationInMultilineDocBlock.php',
             'script-with-anonymous-class' => __DIR__ . '/../../Fixture/Classes/FinalRule/Success/anonymous-class.php',
             'trait' => __DIR__ . '/../../Fixture/Classes/FinalRule/Success/ExampleTrait.php',
             'trait-with-anonymous-class' => __DIR__ . '/../../Fixture/Classes/FinalRule/Success/TraitWithAnonymousClass.php',
@@ -64,6 +68,46 @@ final class FinalRuleTest extends AbstractTestCase
                         Fixture\Classes\FinalRule\Failure\NeitherAbstractNorFinalClass::class
                     ),
                     7,
+                ],
+            ],
+            'non-final-class-without-entity-annotation-in-inline-doc-block' => [
+                __DIR__ . '/../../Fixture/Classes/FinalRule/Failure/NonFinalClassWithoutEntityAnnotationInInlineDocBlock.php',
+                [
+                    \sprintf(
+                        'Class %s is not final.',
+                        Fixture\Classes\FinalRule\Failure\NonFinalClassWithoutEntityAnnotationInInlineDocBlock::class
+                    ),
+                    8,
+                ],
+            ],
+            'non-final-class-without-entity-annotation-in-multi-line-doc-block' => [
+                __DIR__ . '/../../Fixture/Classes/FinalRule/Failure/NonFinalClassWithoutEntityAnnotationInMultilineDocBlock.php',
+                [
+                    \sprintf(
+                        'Class %s is not final.',
+                        Fixture\Classes\FinalRule\Failure\NonFinalClassWithoutEntityAnnotationInMultilineDocBlock::class
+                    ),
+                    11,
+                ],
+            ],
+            'non-final-class-without-orm-entity-annotation-in-inline-doc-block' => [
+                __DIR__ . '/../../Fixture/Classes/FinalRule/Failure/NonFinalClassWithoutOrmEntityAnnotationInInlineDocBlock.php',
+                [
+                    \sprintf(
+                        'Class %s is not final.',
+                        Fixture\Classes\FinalRule\Failure\NonFinalClassWithoutOrmEntityAnnotationInInlineDocBlock::class
+                    ),
+                    8,
+                ],
+            ],
+            'non-final-class-without-orm-entity-annotation-in-multi-line-doc-block' => [
+                __DIR__ . '/../../Fixture/Classes/FinalRule/Failure/NonFinalClassWithoutOrmEntityAnnotationInMultilineDocBlock.php',
+                [
+                    \sprintf(
+                        'Class %s is not final.',
+                        Fixture\Classes\FinalRule\Failure\NonFinalClassWithoutOrmEntityAnnotationInMultilineDocBlock::class
+                    ),
+                    11,
                 ],
             ],
         ];


### PR DESCRIPTION
This PR

* [x] adjusts `Classes\FinalRule` to ignore Doctrine entities

Fixes #78.

💁‍♂ Inspired by the work on [`PhpCsFixer\Fixer\ClassNotation\FinalClassFixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/2.15/src/Fixer/ClassNotation/FinalClassFixer.php) and [`PhpCsFixer\Fixer\ClassNotation\FinalInternalClassFixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/2.15/src/Fixer/ClassNotation/FinalInternalClassFixer.php), contributed by @keradus, @Slamdunk, and @Spacepossum for [`friendsofphp/php-cs-fixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer).