### PR TITLE
Enhancement: Update localheinz/php-cs-fixer-config

### DIFF
--- a/.php_cs.fixture
+++ b/.php_cs.fixture
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Localheinz\PhpCsFixer\Config;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71(''), [
+    'final_class' => false,
     'lowercase_constants' => false,
     'lowercase_keywords' => false,
     'magic_method_casing' => false,

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "require-dev": {
     "infection/infection": "~0.12.0",
     "localheinz/composer-normalize": "^1.1.1",
-    "localheinz/php-cs-fixer-config": "~1.20.0",
+    "localheinz/php-cs-fixer-config": "~1.21.0",
     "localheinz/test-util": "~0.7.0",
     "phpstan/phpstan-deprecation-rules": "~0.10.2 || ~0.11.0",
     "phpstan/phpstan-strict-rules": "~0.10.1 || ~0.11.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a291af9cd377f042d4f50a538c4e190e",
+    "content-hash": "2c2919f113ded46097925c88e5c31b56",
     "packages": [
         {
             "name": "composer/xdebug-handler",
@@ -1390,16 +1390,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.14.2",
+            "version": "v2.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "ff401e58261ffc5934a58f795b3f95b355e276cb"
+                "reference": "adfab51ae979ee8b0fcbc55aa231ec2786cb1f91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/ff401e58261ffc5934a58f795b3f95b355e276cb",
-                "reference": "ff401e58261ffc5934a58f795b3f95b355e276cb",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/adfab51ae979ee8b0fcbc55aa231ec2786cb1f91",
+                "reference": "adfab51ae979ee8b0fcbc55aa231ec2786cb1f91",
                 "shasum": ""
             },
             "require": {
@@ -1427,10 +1427,10 @@
                 "mikey179/vfsstream": "^1.6",
                 "php-coveralls/php-coveralls": "^2.1",
                 "php-cs-fixer/accessible-object": "^1.0",
-                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.0.1",
-                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.0.1",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.1",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.1",
                 "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1",
-                "phpunitgoodpractices/traits": "^1.5.1",
+                "phpunitgoodpractices/traits": "^1.8",
                 "symfony/phpunit-bridge": "^4.0"
             },
             "suggest": {
@@ -1443,6 +1443,11 @@
                 "php-cs-fixer"
             ],
             "type": "application",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.15-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "PhpCsFixer\\": "src/"
@@ -1474,7 +1479,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2019-02-17T17:44:13+00:00"
+            "time": "2019-05-06T07:13:51+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -1944,20 +1949,20 @@
         },
         {
             "name": "localheinz/php-cs-fixer-config",
-            "version": "1.20.0",
+            "version": "1.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/localheinz/php-cs-fixer-config.git",
-                "reference": "17150988bef165e89525bde8a62bb21883201dd9"
+                "reference": "4566ad0f1b7f80352cf0bed27a67d9df7937441d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localheinz/php-cs-fixer-config/zipball/17150988bef165e89525bde8a62bb21883201dd9",
-                "reference": "17150988bef165e89525bde8a62bb21883201dd9",
+                "url": "https://api.github.com/repos/localheinz/php-cs-fixer-config/zipball/4566ad0f1b7f80352cf0bed27a67d9df7937441d",
+                "reference": "4566ad0f1b7f80352cf0bed27a67d9df7937441d",
                 "shasum": ""
             },
             "require": {
-                "friendsofphp/php-cs-fixer": "~2.14.2",
+                "friendsofphp/php-cs-fixer": "~2.15.0",
                 "php": "^5.6 || ^7.0"
             },
             "require-dev": {
@@ -1981,7 +1986,7 @@
             ],
             "description": "Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer.",
             "homepage": "https://github.com/localheinz/php-cs-fixer-config",
-            "time": "2019-03-31T12:40:54+00:00"
+            "time": "2019-05-06T20:15:45+00:00"
         },
         {
             "name": "localheinz/test-util",


### PR DESCRIPTION
This PR

* [x] updates `localheinz/php-cs-fixer-config`
* [x] disables the `final_class` fixer for fixtures

💁‍♂ For reference, see https://github.com/localheinz/php-cs-fixer-config/compare/1.20.0...1.21.0.