### PR TITLE
Fix: Replace Generator return type declaration with less specific iterable

### DIFF
--- a/test/Integration/AbstractTestCase.php
+++ b/test/Integration/AbstractTestCase.php
@@ -53,7 +53,7 @@ abstract class AbstractTestCase extends RuleTestCase
         );
     }
 
-    abstract public function providerAnalysisSucceeds(): \Generator;
+    abstract public function providerAnalysisSucceeds(): iterable;
 
-    abstract public function providerAnalysisFails(): \Generator;
+    abstract public function providerAnalysisFails(): iterable;
 }

--- a/test/Integration/Classes/FinalRuleTest.php
+++ b/test/Integration/Classes/FinalRuleTest.php
@@ -25,7 +25,7 @@ use PHPStan\Rules\Rule;
  */
 final class FinalRuleTest extends AbstractTestCase
 {
-    public function providerAnalysisSucceeds(): \Generator
+    public function providerAnalysisSucceeds(): iterable
     {
         $paths = [
             'final-class' => __DIR__ . '/../../Fixture/Classes/FinalRule/Success/FinalClass.php',
@@ -47,7 +47,7 @@ final class FinalRuleTest extends AbstractTestCase
         }
     }
 
-    public function providerAnalysisFails(): \Generator
+    public function providerAnalysisFails(): iterable
     {
         $paths = [
             'abstract-class' => [

--- a/test/Integration/Classes/FinalRuleWithAbstractClassesAllowedTest.php
+++ b/test/Integration/Classes/FinalRuleWithAbstractClassesAllowedTest.php
@@ -25,7 +25,7 @@ use PHPStan\Rules\Rule;
  */
 final class FinalRuleWithAbstractClassesAllowedTest extends AbstractTestCase
 {
-    public function providerAnalysisSucceeds(): \Generator
+    public function providerAnalysisSucceeds(): iterable
     {
         $paths = [
             'abstract-class' => __DIR__ . '/../../Fixture/Classes/FinalRuleWithAbstractClassesAllowed/Failure/AbstractClass.php',
@@ -44,7 +44,7 @@ final class FinalRuleWithAbstractClassesAllowedTest extends AbstractTestCase
         }
     }
 
-    public function providerAnalysisFails(): \Generator
+    public function providerAnalysisFails(): iterable
     {
         $paths = [
             'neither-abstract-nor-final-class' => [

--- a/test/Integration/Classes/FinalRuleWithExcludedClassNamesTest.php
+++ b/test/Integration/Classes/FinalRuleWithExcludedClassNamesTest.php
@@ -25,7 +25,7 @@ use PHPStan\Rules\Rule;
  */
 final class FinalRuleWithExcludedClassNamesTest extends AbstractTestCase
 {
-    public function providerAnalysisSucceeds(): \Generator
+    public function providerAnalysisSucceeds(): iterable
     {
         $paths = [
             'final-class' => __DIR__ . '/../../Fixture/Classes/FinalRuleWithExcludedClassNames/Success/FinalClass.php',
@@ -44,7 +44,7 @@ final class FinalRuleWithExcludedClassNamesTest extends AbstractTestCase
         }
     }
 
-    public function providerAnalysisFails(): \Generator
+    public function providerAnalysisFails(): iterable
     {
         $paths = [
             'abstract-class' => [

--- a/test/Integration/Classes/NoExtendsRuleTest.php
+++ b/test/Integration/Classes/NoExtendsRuleTest.php
@@ -25,7 +25,7 @@ use PHPStan\Rules\Rule;
  */
 final class NoExtendsRuleTest extends AbstractTestCase
 {
-    public function providerAnalysisSucceeds(): \Generator
+    public function providerAnalysisSucceeds(): iterable
     {
         $paths = [
             'class' => __DIR__ . '/../../Fixture/Classes/NoExtendsRule/Success/ExampleClass.php',
@@ -42,7 +42,7 @@ final class NoExtendsRuleTest extends AbstractTestCase
         }
     }
 
-    public function providerAnalysisFails(): \Generator
+    public function providerAnalysisFails(): iterable
     {
         $paths = [
             'class-extending-other-class' => [

--- a/test/Integration/Classes/NoExtendsRuleWithClassesAllowedToBeExtendedTest.php
+++ b/test/Integration/Classes/NoExtendsRuleWithClassesAllowedToBeExtendedTest.php
@@ -25,7 +25,7 @@ use PHPStan\Rules\Rule;
  */
 final class NoExtendsRuleWithClassesAllowedToBeExtendedTest extends AbstractTestCase
 {
-    public function providerAnalysisSucceeds(): \Generator
+    public function providerAnalysisSucceeds(): iterable
     {
         $paths = [
             'class' => __DIR__ . '/../../Fixture/Classes/NoExtendsRuleWithClassesAllowedToBeExtended/Success/ExampleClass.php',
@@ -44,7 +44,7 @@ final class NoExtendsRuleWithClassesAllowedToBeExtendedTest extends AbstractTest
         }
     }
 
-    public function providerAnalysisFails(): \Generator
+    public function providerAnalysisFails(): iterable
     {
         $paths = [
             'class-extending-other-class' => [

--- a/test/Integration/Closures/NoNullableReturnTypeDeclarationRuleTest.php
+++ b/test/Integration/Closures/NoNullableReturnTypeDeclarationRuleTest.php
@@ -24,7 +24,7 @@ use PHPStan\Rules\Rule;
  */
 final class NoNullableReturnTypeDeclarationRuleTest extends AbstractTestCase
 {
-    public function providerAnalysisSucceeds(): \Generator
+    public function providerAnalysisSucceeds(): iterable
     {
         $paths = [
             'closure-with-return-type-declaration' => __DIR__ . '/../../Fixture/Closures/NoNullableReturnTypeDeclarationRule/Success/closure-with-return-type-declaration.php',
@@ -38,7 +38,7 @@ final class NoNullableReturnTypeDeclarationRuleTest extends AbstractTestCase
         }
     }
 
-    public function providerAnalysisFails(): \Generator
+    public function providerAnalysisFails(): iterable
     {
         $paths = [
             'closure-with-nullable-return-type-declaration' => [

--- a/test/Integration/Closures/NoParameterWithNullDefaultValueRuleTest.php
+++ b/test/Integration/Closures/NoParameterWithNullDefaultValueRuleTest.php
@@ -24,7 +24,7 @@ use PHPStan\Rules\Rule;
  */
 final class NoParameterWithNullDefaultValueRuleTest extends AbstractTestCase
 {
-    public function providerAnalysisSucceeds(): \Generator
+    public function providerAnalysisSucceeds(): iterable
     {
         $paths = [
             'closure-with-parameter-with-non-null-default-value' => __DIR__ . '/../../Fixture/Closures/NoParameterWithNullDefaultValueRule/Success/closure-with-parameter-with-non-null-default-value.php',
@@ -39,7 +39,7 @@ final class NoParameterWithNullDefaultValueRuleTest extends AbstractTestCase
         }
     }
 
-    public function providerAnalysisFails(): \Generator
+    public function providerAnalysisFails(): iterable
     {
         $paths = [
             'closure-with-parameter-with-null-default-value' => [

--- a/test/Integration/Closures/NoParameterWithNullableTypeDeclarationRuleTest.php
+++ b/test/Integration/Closures/NoParameterWithNullableTypeDeclarationRuleTest.php
@@ -24,7 +24,7 @@ use PHPStan\Rules\Rule;
  */
 final class NoParameterWithNullableTypeDeclarationRuleTest extends AbstractTestCase
 {
-    public function providerAnalysisSucceeds(): \Generator
+    public function providerAnalysisSucceeds(): iterable
     {
         $paths = [
             'closure-with-parameter-with-type-declaration' => __DIR__ . '/../../Fixture/Closures/NoParameterWithNullableTypeDeclarationRule/Success/closure-with-parameter-with-type-declaration.php',
@@ -39,7 +39,7 @@ final class NoParameterWithNullableTypeDeclarationRuleTest extends AbstractTestC
         }
     }
 
-    public function providerAnalysisFails(): \Generator
+    public function providerAnalysisFails(): iterable
     {
         $paths = [
             'closure-with-parameter-with-nullable-type-declaration' => [

--- a/test/Integration/Expressions/NoIssetRuleTest.php
+++ b/test/Integration/Expressions/NoIssetRuleTest.php
@@ -24,7 +24,7 @@ use PHPStan\Rules\Rule;
  */
 final class NoIssetRuleTest extends AbstractTestCase
 {
-    public function providerAnalysisSucceeds(): \Generator
+    public function providerAnalysisSucceeds(): iterable
     {
         $paths = [
             'isset-not-used' => __DIR__ . '/../../Fixture/Expressions/NoIssetRule/Success/isset-not-used.php',
@@ -37,7 +37,7 @@ final class NoIssetRuleTest extends AbstractTestCase
         }
     }
 
-    public function providerAnalysisFails(): \Generator
+    public function providerAnalysisFails(): iterable
     {
         $paths = [
             'isset-used-with-correct-case' => [

--- a/test/Integration/Functions/NoNullableReturnTypeDeclarationRuleTest.php
+++ b/test/Integration/Functions/NoNullableReturnTypeDeclarationRuleTest.php
@@ -24,7 +24,7 @@ use PHPStan\Rules\Rule;
  */
 final class NoNullableReturnTypeDeclarationRuleTest extends AbstractTestCase
 {
-    public function providerAnalysisSucceeds(): \Generator
+    public function providerAnalysisSucceeds(): iterable
     {
         $paths = [
             'function-with-return-type-declaration' => __DIR__ . '/../../Fixture/Functions/NoNullableReturnTypeDeclarationRule/Success/function-with-return-type-declaration.php',
@@ -38,7 +38,7 @@ final class NoNullableReturnTypeDeclarationRuleTest extends AbstractTestCase
         }
     }
 
-    public function providerAnalysisFails(): \Generator
+    public function providerAnalysisFails(): iterable
     {
         $paths = [
             'function-with-nullable-return-type-declaration' => [

--- a/test/Integration/Functions/NoParameterWithNullDefaultValueRuleTest.php
+++ b/test/Integration/Functions/NoParameterWithNullDefaultValueRuleTest.php
@@ -24,7 +24,7 @@ use PHPStan\Rules\Rule;
  */
 final class NoParameterWithNullDefaultValueRuleTest extends AbstractTestCase
 {
-    public function providerAnalysisSucceeds(): \Generator
+    public function providerAnalysisSucceeds(): iterable
     {
         $paths = [
             'function-with-parameter-with-non-null-default-value' => __DIR__ . '/../../Fixture/Functions/NoParameterWithNullDefaultValueRule/Success/function-with-parameter-with-non-null-default-value.php',
@@ -39,7 +39,7 @@ final class NoParameterWithNullDefaultValueRuleTest extends AbstractTestCase
         }
     }
 
-    public function providerAnalysisFails(): \Generator
+    public function providerAnalysisFails(): iterable
     {
         $paths = [
             'function-with-parameter-with-null-default-value' => [

--- a/test/Integration/Functions/NoParameterWithNullableTypeDeclarationRuleTest.php
+++ b/test/Integration/Functions/NoParameterWithNullableTypeDeclarationRuleTest.php
@@ -24,7 +24,7 @@ use PHPStan\Rules\Rule;
  */
 final class NoParameterWithNullableTypeDeclarationRuleTest extends AbstractTestCase
 {
-    public function providerAnalysisSucceeds(): \Generator
+    public function providerAnalysisSucceeds(): iterable
     {
         $paths = [
             'function-with-parameter-with-type-declaration' => __DIR__ . '/../../Fixture/Functions/NoParameterWithNullableTypeDeclarationRule/Success/function-with-parameter-with-type-declaration.php',
@@ -39,7 +39,7 @@ final class NoParameterWithNullableTypeDeclarationRuleTest extends AbstractTestC
         }
     }
 
-    public function providerAnalysisFails(): \Generator
+    public function providerAnalysisFails(): iterable
     {
         $paths = [
             'function-with-parameter-with-nullable-type-declaration' => [

--- a/test/Integration/Methods/NoConstructorParameterWithDefaultValueRuleTest.php
+++ b/test/Integration/Methods/NoConstructorParameterWithDefaultValueRuleTest.php
@@ -25,7 +25,7 @@ use PHPStan\Rules\Rule;
  */
 final class NoConstructorParameterWithDefaultValueRuleTest extends AbstractTestCase
 {
-    public function providerAnalysisSucceeds(): \Generator
+    public function providerAnalysisSucceeds(): iterable
     {
         $paths = [
             'constructor-in-anonymous-class-with-parameter-without-default-value' => __DIR__ . '/../../Fixture/Methods/NoConstructorParameterWithDefaultValueRule/Success/constructor-in-anonymous-class-with-parameter-without-default-value.php',
@@ -49,7 +49,7 @@ final class NoConstructorParameterWithDefaultValueRuleTest extends AbstractTestC
         }
     }
 
-    public function providerAnalysisFails(): \Generator
+    public function providerAnalysisFails(): iterable
     {
         $paths = [
             'constructor-in-anonymous-class-with-parameter-with-default-value' => [

--- a/test/Integration/Methods/NoNullableReturnTypeDeclarationRuleTest.php
+++ b/test/Integration/Methods/NoNullableReturnTypeDeclarationRuleTest.php
@@ -25,7 +25,7 @@ use PHPStan\Rules\Rule;
  */
 final class NoNullableReturnTypeDeclarationRuleTest extends AbstractTestCase
 {
-    public function providerAnalysisSucceeds(): \Generator
+    public function providerAnalysisSucceeds(): iterable
     {
         $paths = [
             'method-in-anonymous-class-with-return-type-declaration' => __DIR__ . '/../../Fixture/Methods/NoNullableReturnTypeDeclarationRule/Success/MethodInAnonymousClassWithReturnTypeDeclaration.php',
@@ -47,7 +47,7 @@ final class NoNullableReturnTypeDeclarationRuleTest extends AbstractTestCase
         }
     }
 
-    public function providerAnalysisFails(): \Generator
+    public function providerAnalysisFails(): iterable
     {
         $paths = [
             'method-in-anonymous-class-with-nullable-return-type-declaration' => [

--- a/test/Integration/Methods/NoParameterWithNullDefaultValueRuleTest.php
+++ b/test/Integration/Methods/NoParameterWithNullDefaultValueRuleTest.php
@@ -25,7 +25,7 @@ use PHPStan\Rules\Rule;
  */
 final class NoParameterWithNullDefaultValueRuleTest extends AbstractTestCase
 {
-    public function providerAnalysisSucceeds(): \Generator
+    public function providerAnalysisSucceeds(): iterable
     {
         $paths = [
             'method-in-anonymous-class-with-parameter-with-non-null-default-value' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullDefaultValueRule/Success/method-in-anonymous-class-with-parameter-with-non-null-default-value.php',
@@ -53,7 +53,7 @@ final class NoParameterWithNullDefaultValueRuleTest extends AbstractTestCase
         }
     }
 
-    public function providerAnalysisFails(): \Generator
+    public function providerAnalysisFails(): iterable
     {
         $paths = [
             'method-in-anonymous-class-with-parameter-with-null-default-value' => [

--- a/test/Integration/Methods/NoParameterWithNullableTypeDeclarationRuleTest.php
+++ b/test/Integration/Methods/NoParameterWithNullableTypeDeclarationRuleTest.php
@@ -25,7 +25,7 @@ use PHPStan\Rules\Rule;
  */
 final class NoParameterWithNullableTypeDeclarationRuleTest extends AbstractTestCase
 {
-    public function providerAnalysisSucceeds(): \Generator
+    public function providerAnalysisSucceeds(): iterable
     {
         $paths = [
             'method-in-anonymous-class-with-parameter-with-type-declaration' => __DIR__ . '/../../Fixture/Methods/NoParameterWithNullableTypeDeclarationRule/Success/method-in-anonymous-class-with-parameter-with-type-declaration.php',
@@ -50,7 +50,7 @@ final class NoParameterWithNullableTypeDeclarationRuleTest extends AbstractTestC
         }
     }
 
-    public function providerAnalysisFails(): \Generator
+    public function providerAnalysisFails(): iterable
     {
         $paths = [
             'method-in-anonymous-class-with-parameter-with-nullable-type-declaration' => [


### PR DESCRIPTION
This PR

* [x] replaces the `Generator` return type declaration with the less specific `iterable`

/cc @Slamdunk
