### PR TITLE
Enhancement: Implement Expressions\NoEmptyRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`0.10.0...master`](https://github.com/localheinz/phpstan-ru
 ### Added
 
 * Added `Files\DeclareStrictTypesRule`, which reports an error when a PHP file does not have a `declare(strict_types=1)` declaration ([#79](https://github.com/localheinz/phpstan-rules/pull/79)), by [@dmecke](https://github.com/dmecke)
+* Added `Expressions\NoEmptyRule`, which reports an error when the language construct `empty()` is used ([#110](https://github.com/localheinz/phpstan-rules/pull/110)), by [@localheinz](https://github.com/localheinz)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This package provides the following rules for use with [`phpstan/phpstan`](https
 * [`Localheinz\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#closuresnonullablereturntypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#closuresnoparameterwithnullabletypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Closures\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#closuresnoparameterwithnulldefaultvaluerule)
+* [`Localheinz\PHPStan\Rules\Expressions\NoEmptyRule`](https://github.com/localheinz/phpstan-rules#expressionsnoemptyrule)
 * [`Localheinz\PHPStan\Rules\Expressions\NoIssetRule`](https://github.com/localheinz/phpstan-rules#expressionsnoissetrule)
 * [`Localheinz\PHPStan\Rules\Files\DeclareStrictTypesRule`](https://github.com/localheinz/phpstan-rules#filesdeclarestricttypesrule)
 * [`Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#functionsnonullablereturntypedeclarationrule)
@@ -117,6 +118,10 @@ This rule reports an error when a closure has a parameter with a nullable type d
 This rule reports an error when a closure has a parameter with `null` as default value.
 
 ### Expressions
+
+#### `Expressions\NoEmptyRule`
+
+This rule reports an error when the language construct [`empty()`](https://www.php.net/empty) is used.
 
 #### `Expressions\NoIssetRule`
 

--- a/rules.neon
+++ b/rules.neon
@@ -11,6 +11,7 @@ parametersSchema:
 rules:
 	- Localheinz\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule
+	- Localheinz\PHPStan\Rules\Expressions\NoEmptyRule
 	- Localheinz\PHPStan\Rules\Expressions\NoIssetRule
 	- Localheinz\PHPStan\Rules\Files\DeclareStrictTypesRule
 	- Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule

--- a/src/Expressions/NoEmptyRule.php
+++ b/src/Expressions/NoEmptyRule.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Expressions;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+
+final class NoEmptyRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Expr\Empty_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        return [
+            'Language construct empty() should not be used.',
+        ];
+    }
+}

--- a/test/Fixture/Expressions/NoEmptyRule/Failure/empty-used-with-correct-case.php
+++ b/test/Fixture/Expressions/NoEmptyRule/Failure/empty-used-with-correct-case.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoEmptyRule\Failure;
+
+if (empty($foo)) {
+    echo 'Hello!';
+}

--- a/test/Fixture/Expressions/NoEmptyRule/Failure/empty-used-with-incorrect-case.php
+++ b/test/Fixture/Expressions/NoEmptyRule/Failure/empty-used-with-incorrect-case.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoEmptuRule\Failure;
+
+if (eMpTy($foo)) {
+    echo 'Hello!';
+}

--- a/test/Fixture/Expressions/NoEmptyRule/Success/empty-not-used.php
+++ b/test/Fixture/Expressions/NoEmptyRule/Success/empty-not-used.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoEmptyRule\Success;
+
+function _empty(): bool
+{
+    return false;
+}
+
+if (_empty()) {
+    echo 'Hello!';
+}

--- a/test/Integration/Expressions/NoEmptyRuleTest.php
+++ b/test/Integration/Expressions/NoEmptyRuleTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Integration\Expressions;
+
+use Localheinz\PHPStan\Rules\Expressions\NoEmptyRule;
+use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use PHPStan\Rules\Rule;
+
+/**
+ * @internal
+ *
+ * @covers \Localheinz\PHPStan\Rules\Expressions\NoEmptyRule
+ */
+final class NoEmptyRuleTest extends AbstractTestCase
+{
+    public function providerAnalysisSucceeds(): iterable
+    {
+        $paths = [
+            'empty-not-used' => __DIR__ . '/../../Fixture/Expressions/NoEmptyRule/Success/empty-not-used.php',
+        ];
+
+        foreach ($paths as $description => $path) {
+            yield $description => [
+                $path,
+            ];
+        }
+    }
+
+    public function providerAnalysisFails(): iterable
+    {
+        $paths = [
+            'empty-used-with-correct-case' => [
+                __DIR__ . '/../../Fixture/Expressions/NoEmptyRule/Failure/empty-used-with-correct-case.php',
+                [
+                    'Language construct empty() should not be used.',
+                    7,
+                ],
+            ],
+            'empty-used-with-incorrect-case' => [
+                __DIR__ . '/../../Fixture/Expressions/NoEmptyRule/Failure/empty-used-with-incorrect-case.php',
+                [
+                    'Language construct empty() should not be used.',
+                    7,
+                ],
+            ],
+        ];
+
+        foreach ($paths as $description => [$path, $error]) {
+            yield $description => [
+                $path,
+                $error,
+            ];
+        }
+    }
+
+    protected function getRule(): Rule
+    {
+        return new NoEmptyRule();
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements an `Expressions\NoEmptyRule`, which reports an error when the language construct `empty()` is used