### PR TITLE
Enhancement: Implement Expressions\NoEvalRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`0.10.0...master`](https://github.com/localheinz/phpstan-ru
 
 * Added `Files\DeclareStrictTypesRule`, which reports an error when a PHP file does not have a `declare(strict_types=1)` declaration ([#79](https://github.com/localheinz/phpstan-rules/pull/79)), by [@dmecke](https://github.com/dmecke)
 * Added `Expressions\NoEmptyRule`, which reports an error when the language construct `empty()` is used ([#110](https://github.com/localheinz/phpstan-rules/pull/110)), by [@localheinz](https://github.com/localheinz)
+* Added `Expressions\NoEvalRule`, which reports an error when the language construct `eval()` is used ([#112](https://github.com/localheinz/phpstan-rules/pull/112)), by [@localheinz](https://github.com/localheinz)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This package provides the following rules for use with [`phpstan/phpstan`](https
 * [`Localheinz\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#closuresnoparameterwithnullabletypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Closures\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#closuresnoparameterwithnulldefaultvaluerule)
 * [`Localheinz\PHPStan\Rules\Expressions\NoEmptyRule`](https://github.com/localheinz/phpstan-rules#expressionsnoemptyrule)
+* [`Localheinz\PHPStan\Rules\Expressions\NoEvalRule`](https://github.com/localheinz/phpstan-rules#expressionsnoevalrule)
 * [`Localheinz\PHPStan\Rules\Expressions\NoIssetRule`](https://github.com/localheinz/phpstan-rules#expressionsnoissetrule)
 * [`Localheinz\PHPStan\Rules\Files\DeclareStrictTypesRule`](https://github.com/localheinz/phpstan-rules#filesdeclarestricttypesrule)
 * [`Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#functionsnonullablereturntypedeclarationrule)
@@ -122,6 +123,10 @@ This rule reports an error when a closure has a parameter with `null` as default
 #### `Expressions\NoEmptyRule`
 
 This rule reports an error when the language construct [`empty()`](https://www.php.net/empty) is used.
+
+#### `Expressions\NoEvalRule`
+
+This rule reports an error when the language construct [`eval()`](https://www.php.net/eval) is used.
 
 #### `Expressions\NoIssetRule`
 

--- a/rules.neon
+++ b/rules.neon
@@ -12,6 +12,7 @@ rules:
 	- Localheinz\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Expressions\NoEmptyRule
+	- Localheinz\PHPStan\Rules\Expressions\NoEvalRule
 	- Localheinz\PHPStan\Rules\Expressions\NoIssetRule
 	- Localheinz\PHPStan\Rules\Files\DeclareStrictTypesRule
 	- Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule

--- a/src/Expressions/NoEvalRule.php
+++ b/src/Expressions/NoEvalRule.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Expressions;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+
+final class NoEvalRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Expr\Eval_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        return [
+            'Language construct eval() should not be used.',
+        ];
+    }
+}

--- a/test/Fixture/Expressions/NoEvalRule/Failure/eval-used-with-correct-case.php
+++ b/test/Fixture/Expressions/NoEvalRule/Failure/eval-used-with-correct-case.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoEvalRule\Failure;
+
+eval('echo $foo');

--- a/test/Fixture/Expressions/NoEvalRule/Failure/eval-used-with-incorrect-case.php
+++ b/test/Fixture/Expressions/NoEvalRule/Failure/eval-used-with-incorrect-case.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoEvalRule\Failure;
+
+eVaL('echo $foo');

--- a/test/Fixture/Expressions/NoEvalRule/Success/eval-not-used.php
+++ b/test/Fixture/Expressions/NoEvalRule/Success/eval-not-used.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoEvalRule\Success;
+
+function _eval(string $argument): void
+{
+}
+
+_eval('echo $foo');

--- a/test/Integration/Expressions/NoEvalRuleTest.php
+++ b/test/Integration/Expressions/NoEvalRuleTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Integration\Expressions;
+
+use Localheinz\PHPStan\Rules\Expressions\NoEvalRule;
+use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use PHPStan\Rules\Rule;
+
+/**
+ * @internal
+ *
+ * @covers \Localheinz\PHPStan\Rules\Expressions\NoEvalRule
+ */
+final class NoEvalRuleTest extends AbstractTestCase
+{
+    public function providerAnalysisSucceeds(): iterable
+    {
+        $paths = [
+            'eval-not-used' => __DIR__ . '/../../Fixture/Expressions/NoEvalRule/Success/eval-not-used.php',
+        ];
+
+        foreach ($paths as $description => $path) {
+            yield $description => [
+                $path,
+            ];
+        }
+    }
+
+    public function providerAnalysisFails(): iterable
+    {
+        $paths = [
+            'eval-used-with-correct-case' => [
+                __DIR__ . '/../../Fixture/Expressions/NoEvalRule/Failure/eval-used-with-correct-case.php',
+                [
+                    'Language construct eval() should not be used.',
+                    7,
+                ],
+            ],
+            'eval-used-with-incorrect-case' => [
+                __DIR__ . '/../../Fixture/Expressions/NoEvalRule/Failure/eval-used-with-incorrect-case.php',
+                [
+                    'Language construct eval() should not be used.',
+                    7,
+                ],
+            ],
+        ];
+
+        foreach ($paths as $description => [$path, $error]) {
+            yield $description => [
+                $path,
+                $error,
+            ];
+        }
+    }
+
+    protected function getRule(): Rule
+    {
+        return new NoEvalRule();
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements an `Expressions\NoEvalRule`, which reports an error when the language construct `eval()` is used