### PR TITLE
Enhancement: Implement Expressions\NoErrorSuppressionRule

### DIFF
--- a/.php_cs.fixture
+++ b/.php_cs.fixture
@@ -6,6 +6,7 @@ use Localheinz\PhpCsFixer\Config;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71(''), [
     'declare_strict_types' => false,
+    'error_suppression' => false,
     'final_class' => false,
     'header_comment' => false,
     'lowercase_constants' => false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a full diff see [`0.10.0...master`](https://github.com/localheinz/phpstan-ru
 * Added `Files\DeclareStrictTypesRule`, which reports an error when a PHP file does not have a `declare(strict_types=1)` declaration ([#79](https://github.com/localheinz/phpstan-rules/pull/79)), by [@dmecke](https://github.com/dmecke)
 * Added `Expressions\NoEmptyRule`, which reports an error when the language construct `empty()` is used ([#110](https://github.com/localheinz/phpstan-rules/pull/110)), by [@localheinz](https://github.com/localheinz)
 * Added `Expressions\NoEvalRule`, which reports an error when the language construct `eval()` is used ([#112](https://github.com/localheinz/phpstan-rules/pull/112)), by [@localheinz](https://github.com/localheinz)
+* Added `Expressions\NoErrorSuppressionRule`, which reports an error when `@` is used to suppress errors ([#113](https://github.com/localheinz/phpstan-rules/pull/113)), by [@dmecke](https://github.com/dmecke)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This package provides the following rules for use with [`phpstan/phpstan`](https
 * [`Localheinz\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#closuresnoparameterwithnullabletypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Closures\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#closuresnoparameterwithnulldefaultvaluerule)
 * [`Localheinz\PHPStan\Rules\Expressions\NoEmptyRule`](https://github.com/localheinz/phpstan-rules#expressionsnoemptyrule)
+* [`Localheinz\PHPStan\Rules\Expressions\NoErrorSuppressionRule`](https://github.com/localheinz/phpstan-rules#expressionserrorsuppressionrule)
 * [`Localheinz\PHPStan\Rules\Expressions\NoEvalRule`](https://github.com/localheinz/phpstan-rules#expressionsnoevalrule)
 * [`Localheinz\PHPStan\Rules\Expressions\NoIssetRule`](https://github.com/localheinz/phpstan-rules#expressionsnoissetrule)
 * [`Localheinz\PHPStan\Rules\Files\DeclareStrictTypesRule`](https://github.com/localheinz/phpstan-rules#filesdeclarestricttypesrule)
@@ -127,6 +128,10 @@ This rule reports an error when the language construct [`empty()`](https://www.p
 #### `Expressions\NoEvalRule`
 
 This rule reports an error when the language construct [`eval()`](https://www.php.net/eval) is used.
+
+#### `Expressions\NoErrorSuppressionRule`
+
+This rule reports an error when [`@`](https://www.php.net/manual/en/language.operators.errorcontrol.php) is used to suppress errors.
 
 #### `Expressions\NoIssetRule`
 

--- a/rules.neon
+++ b/rules.neon
@@ -12,6 +12,7 @@ rules:
 	- Localheinz\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Expressions\NoEmptyRule
+	- Localheinz\PHPStan\Rules\Expressions\NoErrorSuppressionRule
 	- Localheinz\PHPStan\Rules\Expressions\NoEvalRule
 	- Localheinz\PHPStan\Rules\Expressions\NoIssetRule
 	- Localheinz\PHPStan\Rules\Files\DeclareStrictTypesRule

--- a/src/Expressions/NoErrorSuppressionRule.php
+++ b/src/Expressions/NoErrorSuppressionRule.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Expressions;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+
+final class NoErrorSuppressionRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Expr\ErrorSuppress::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        return [
+            'Error suppression via "@" should not be used.',
+        ];
+    }
+}

--- a/test/Fixture/Expressions/NoErrorSuppressionRule/Failure/error-suppression-used.php
+++ b/test/Fixture/Expressions/NoErrorSuppressionRule/Failure/error-suppression-used.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoErrorSuppressionRule\Failure;
+
+@\serialize($value);

--- a/test/Fixture/Expressions/NoErrorSuppressionRule/Success/error-suppression-not-used.php
+++ b/test/Fixture/Expressions/NoErrorSuppressionRule/Success/error-suppression-not-used.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoErrorSuppressionRule\Success;
+
+\serialize($value);

--- a/test/Integration/Expressions/NoErrorSuppressionRuleTest.php
+++ b/test/Integration/Expressions/NoErrorSuppressionRuleTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Integration\Expressions;
+
+use Localheinz\PHPStan\Rules\Expressions\NoErrorSuppressionRule;
+use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use PHPStan\Rules\Rule;
+
+/**
+ * @internal
+ *
+ * @covers \Localheinz\PHPStan\Rules\Expressions\NoErrorSuppressionRule
+ */
+final class NoErrorSuppressionRuleTest extends AbstractTestCase
+{
+    public function providerAnalysisSucceeds(): iterable
+    {
+        $paths = [
+            'error-suppression-not-used' => __DIR__ . '/../../Fixture/Expressions/NoErrorSuppressionRule/Success/error-suppression-not-used.php',
+        ];
+
+        foreach ($paths as $description => $path) {
+            yield $description => [
+                $path,
+            ];
+        }
+    }
+
+    public function providerAnalysisFails(): iterable
+    {
+        $paths = [
+            'error-suppression-used' => [
+                __DIR__ . '/../../Fixture/Expressions/NoErrorSuppressionRule/Failure/error-suppression-used.php',
+                [
+                    'Error suppression via "@" should not be used.',
+                    7,
+                ],
+            ],
+        ];
+
+        foreach ($paths as $description => [$path, $error]) {
+            yield $description => [
+                $path,
+                $error,
+            ];
+        }
+    }
+
+    protected function getRule(): Rule
+    {
+        return new NoErrorSuppressionRule();
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements an `Expressions\NoErrorSuppressionRule`, which reports an error when `@` is used to suppress errors