### PR TITLE
Enhancement: Implement Expressions\NoCompactRule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,7 +154,7 @@ jobs:
         - mkdir -p $HOME/.build/infection
 
       script:
-        - vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=95 --min-msi=86
+        - vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=96 --min-msi=86
 
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For a full diff see [`0.10.0...master`](https://github.com/localheinz/phpstan-ru
 * Added `Expressions\NoEmptyRule`, which reports an error when the language construct `empty()` is used ([#110](https://github.com/localheinz/phpstan-rules/pull/110)), by [@localheinz](https://github.com/localheinz)
 * Added `Expressions\NoEvalRule`, which reports an error when the language construct `eval()` is used ([#112](https://github.com/localheinz/phpstan-rules/pull/112)), by [@localheinz](https://github.com/localheinz)
 * Added `Expressions\NoErrorSuppressionRule`, which reports an error when `@` is used to suppress errors ([#113](https://github.com/localheinz/phpstan-rules/pull/113)), by [@localheinz](https://github.com/localheinz)
+* Added `Expressions\NoCompactRule`, which reports an error when the function `compact()` is used ([#116](https://github.com/localheinz/phpstan-rules/pull/116)), by [@localheinz](https://github.com/localheinz)
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ help: ## Displays this list of targets with descriptions
 
 infection: vendor ## Runs mutation tests with infection
 	mkdir -p .build/infection
-	vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=95 --min-msi=86
+	vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=96 --min-msi=86
 
 stan: vendor ## Runs a static analysis with phpstan
 	mkdir -p .build/phpstan

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This package provides the following rules for use with [`phpstan/phpstan`](https
 * [`Localheinz\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#closuresnonullablereturntypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#closuresnoparameterwithnullabletypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Closures\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#closuresnoparameterwithnulldefaultvaluerule)
+* [`Localheinz\PHPStan\Rules\Expressions\NoCompactRule`](https://github.com/localheinz/phpstan-rules#expressionsnocompactrule)
 * [`Localheinz\PHPStan\Rules\Expressions\NoEmptyRule`](https://github.com/localheinz/phpstan-rules#expressionsnoemptyrule)
 * [`Localheinz\PHPStan\Rules\Expressions\NoErrorSuppressionRule`](https://github.com/localheinz/phpstan-rules#expressionserrorsuppressionrule)
 * [`Localheinz\PHPStan\Rules\Expressions\NoEvalRule`](https://github.com/localheinz/phpstan-rules#expressionsnoevalrule)
@@ -120,6 +121,10 @@ This rule reports an error when a closure has a parameter with a nullable type d
 This rule reports an error when a closure has a parameter with `null` as default value.
 
 ### Expressions
+
+#### `Expressions\NoCompactRule`
+
+This rule reports an error when the function [`compact()`](https://www.php.net/compact) is used.
 
 #### `Expressions\NoEmptyRule`
 

--- a/rules.neon
+++ b/rules.neon
@@ -11,6 +11,7 @@ parametersSchema:
 rules:
 	- Localheinz\PHPStan\Rules\Closures\NoNullableReturnTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Closures\NoParameterWithNullableTypeDeclarationRule
+	- Localheinz\PHPStan\Rules\Expressions\NoCompactRule
 	- Localheinz\PHPStan\Rules\Expressions\NoEmptyRule
 	- Localheinz\PHPStan\Rules\Expressions\NoErrorSuppressionRule
 	- Localheinz\PHPStan\Rules\Expressions\NoEvalRule

--- a/src/Expressions/NoCompactRule.php
+++ b/src/Expressions/NoCompactRule.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Expressions;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+
+final class NoCompactRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Expr\FuncCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node instanceof Node\Expr\FuncCall) {
+            throw new ShouldNotHappenException(\sprintf(
+                'Expected node to be instance of "%s", but got instance of "%s" instead.',
+                Node\Expr\FuncCall::class,
+                \get_class($node)
+            ));
+        }
+
+        if (!$node->name instanceof Node\Name) {
+            return [];
+        }
+
+        if ('compact' !== $scope->resolveName($node->name)) {
+            return [];
+        }
+
+        return [
+            'Function compact() should not be used.',
+        ];
+    }
+}

--- a/test/Fixture/Expressions/NoCompactRule/Failure/compact-used-with-alias.php
+++ b/test/Fixture/Expressions/NoCompactRule/Failure/compact-used-with-alias.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoCompactRule\Failure;
+
+use function compact as compress;
+
+$foo = 9000;
+$bar = 42;
+
+return compress(
+    'foo',
+    'bar'
+);

--- a/test/Fixture/Expressions/NoCompactRule/Failure/compact-used-with-correct-case.php
+++ b/test/Fixture/Expressions/NoCompactRule/Failure/compact-used-with-correct-case.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoCompactRule\Failure;
+
+$foo = 9000;
+$bar = 42;
+
+return \compact(
+    'foo',
+    'bar'
+);

--- a/test/Fixture/Expressions/NoCompactRule/Failure/compact-used-with-incorrect-case.php
+++ b/test/Fixture/Expressions/NoCompactRule/Failure/compact-used-with-incorrect-case.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoCompactRule\Failure;
+
+$foo = 9000;
+$bar = 42;
+
+return \compact(
+    'foo',
+    'bar'
+);

--- a/test/Fixture/Expressions/NoCompactRule/Success/compact-not-used.php
+++ b/test/Fixture/Expressions/NoCompactRule/Success/compact-not-used.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoEmptyRule\Success;
+
+function _compact(string ...$names): array
+{
+    return $names;
+}
+
+$foo = 9000;
+$bar = 42;
+
+return _compact(
+    'foo',
+    'bar'
+);

--- a/test/Integration/Expressions/NoCompactRuleTest.php
+++ b/test/Integration/Expressions/NoCompactRuleTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Integration\Expressions;
+
+use Localheinz\PHPStan\Rules\Expressions\NoCompactRule;
+use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use PHPStan\Rules\Rule;
+
+/**
+ * @internal
+ *
+ * @covers \Localheinz\PHPStan\Rules\Expressions\NoCompactRule
+ */
+final class NoCompactRuleTest extends AbstractTestCase
+{
+    public function providerAnalysisSucceeds(): iterable
+    {
+        $paths = [
+            'compact-not-used' => __DIR__ . '/../../Fixture/Expressions/NoCompactRule/Success/compact-not-used.php',
+        ];
+
+        foreach ($paths as $description => $path) {
+            yield $description => [
+                $path,
+            ];
+        }
+    }
+
+    public function providerAnalysisFails(): iterable
+    {
+        $paths = [
+            'compact-used-with-alias' => [
+                __DIR__ . '/../../Fixture/Expressions/NoCompactRule/Failure/compact-used-with-alias.php',
+                [
+                    'Function compact() should not be used.',
+                    12,
+                ],
+            ],
+            'compact-used-with-correct-case' => [
+                __DIR__ . '/../../Fixture/Expressions/NoCompactRule/Failure/compact-used-with-correct-case.php',
+                [
+                    'Function compact() should not be used.',
+                    10,
+                ],
+            ],
+            'compact-used-with-incorrect-case' => [
+                __DIR__ . '/../../Fixture/Expressions/NoCompactRule/Failure/compact-used-with-incorrect-case.php',
+                [
+                    'Function compact() should not be used.',
+                    10,
+                ],
+            ],
+        ];
+
+        foreach ($paths as $description => [$path, $error]) {
+            yield $description => [
+                $path,
+                $error,
+            ];
+        }
+    }
+
+    protected function getRule(): Rule
+    {
+        return new NoCompactRule();
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements an `Expressions\NoCompactRule`, which reports an error when the function  `compact()` is used