### PR TITLE
Enhancement: Implement Statements\NoSwitchRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For a full diff see [`0.10.0...master`](https://github.com/localheinz/phpstan-ru
 * Added `Expressions\NoEvalRule`, which reports an error when the language construct `eval()` is used ([#112](https://github.com/localheinz/phpstan-rules/pull/112)), by [@localheinz](https://github.com/localheinz)
 * Added `Expressions\NoErrorSuppressionRule`, which reports an error when `@` is used to suppress errors ([#113](https://github.com/localheinz/phpstan-rules/pull/113)), by [@localheinz](https://github.com/localheinz)
 * Added `Expressions\NoCompactRule`, which reports an error when the function `compact()` is used ([#116](https://github.com/localheinz/phpstan-rules/pull/116)), by [@localheinz](https://github.com/localheinz)
+* Added `Statements\NoSwitchRule`, which reports an error when the statement `switch()` is used ([#117](https://github.com/localheinz/phpstan-rules/pull/117)), by [@localheinz](https://github.com/localheinz)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This package provides the following rules for use with [`phpstan/phpstan`](https
 * [`Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#methodsnonullablereturntypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#methodsnoparameterwithnullabletypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#methodsnoparameterwithnulldefaultvaluerule)
+* [`Localheinz\PHPStan\Rules\Statements\NoSwitchRule`](https://github.com/localheinz/phpstan-rules#statementsnoswitchrule)
 
 ### Classes
 
@@ -202,6 +203,10 @@ This rule reports an error when a method declared in
 * an interface
 
 has a parameter with `null` as default value.
+
+#### `Statements\NoSwitchRule`
+
+This rule reports an error when the statement [`switch()`](https://www.php.net/manual/control-structures.switch.php) is used.
 
 ## Changelog
 

--- a/rules.neon
+++ b/rules.neon
@@ -24,6 +24,7 @@ rules:
 	- Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule
+	- Localheinz\PHPStan\Rules\Statements\NoSwitchRule
 
 services:
 	-

--- a/src/Statements/NoSwitchRule.php
+++ b/src/Statements/NoSwitchRule.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Statements;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+
+final class NoSwitchRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Stmt\Switch_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        return [
+            'Control structures using switch should not be used.',
+        ];
+    }
+}

--- a/test/Fixture/Statements/NoSwitchRule/Failure/switch-used-with-correct-case.php
+++ b/test/Fixture/Statements/NoSwitchRule/Failure/switch-used-with-correct-case.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoSwitchRule\Failure;
+
+switch ($foo) {
+    case 'foo':
+        return 'It is foo!';
+    case 'bar':
+        return 'It is bar!';
+}

--- a/test/Fixture/Statements/NoSwitchRule/Failure/switch-used-with-incorrect-case.php
+++ b/test/Fixture/Statements/NoSwitchRule/Failure/switch-used-with-incorrect-case.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoSwitchRule\Failure;
+
+sWiTcH ($foo) {
+    case 'foo':
+        return 'It is foo!';
+    case 'bar':
+        return 'It is bar!';
+}

--- a/test/Fixture/Statements/NoSwitchRule/Success/switch-not-used.php
+++ b/test/Fixture/Statements/NoSwitchRule/Success/switch-not-used.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Expressions\NoSwitchRule\Success;
+
+if ('foo' === $foo) {
+    return 'It is foo!';
+}
+
+if ('bar' === $foo) {
+    return 'It is bar!';
+}

--- a/test/Integration/Statements/NoSwitchRuleTest.php
+++ b/test/Integration/Statements/NoSwitchRuleTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Integration\Statements;
+
+use Localheinz\PHPStan\Rules\Statements\NoSwitchRule;
+use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use PHPStan\Rules\Rule;
+
+/**
+ * @internal
+ *
+ * @covers \Localheinz\PHPStan\Rules\Statements\NoSwitchRule
+ */
+final class NoSwitchRuleTest extends AbstractTestCase
+{
+    public function providerAnalysisSucceeds(): iterable
+    {
+        $paths = [
+            'isset-not-used' => __DIR__ . '/../../Fixture/Statements/NoSwitchRule/Success/switch-not-used.php',
+        ];
+
+        foreach ($paths as $description => $path) {
+            yield $description => [
+                $path,
+            ];
+        }
+    }
+
+    public function providerAnalysisFails(): iterable
+    {
+        $paths = [
+            'switch-used-with-correct-case' => [
+                __DIR__ . '/../../Fixture/Statements/NoSwitchRule/Failure/switch-used-with-correct-case.php',
+                [
+                    'Control structures using switch should not be used.',
+                    7,
+                ],
+            ],
+            'isset-used-with-incorrect-case' => [
+                __DIR__ . '/../../Fixture/Statements/NoSwitchRule/Failure/switch-used-with-incorrect-case.php',
+                [
+                    'Control structures using switch should not be used.',
+                    7,
+                ],
+            ],
+        ];
+
+        foreach ($paths as $description => [$path, $error]) {
+            yield $description => [
+                $path,
+                $error,
+            ];
+        }
+    }
+
+    protected function getRule(): Rule
+    {
+        return new NoSwitchRule();
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements a `Statements\NoSwitchRule`, which reports an error when the statement `switch()` is used