### PR TITLE
Enhancement: Implement Methods\FinalInAbstractClassRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.11.0...master`](https://github.com/localheinz/phpstan-rules/compare/0.11.0...master).
+For a full diff see [`0.12.0...master`](https://github.com/localheinz/phpstan-rules/compare/0.12.0...master).
+
+## [`0.12.0`](https://github.com/localheinz/phpstan-rules/releases/tag/0.12.0)
+
+For a full diff see [`0.11.0...0.12.0`](https://github.com/localheinz/phpstan-rules/compare/0.11.0...0.12.0).
 
 ### Added
 
 * Added `Methods\NoParameterWithContainerTypeDeclarationRule`, which reports an error when a method has a type declaration that corresponds to a known dependency injection container or service locator ([#122](https://github.com/localheinz/phpstan-rules/pull/122)), by [@localheinz](https://github.com/localheinz)
+* Added `Methods\FinalInAbstractClassRule`, which reports an error when a concrete `public` or `protected` method in an `abstract` class is not `final` ([#123](https://github.com/localheinz/phpstan-rules/pull/123)), by [@localheinz](https://github.com/localheinz)
 
 ## [`0.11.0`](https://github.com/localheinz/phpstan-rules/releases/tag/0.11.0)
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This package provides the following rules for use with [`phpstan/phpstan`](https
 * [`Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#functionsnonullablereturntypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclaration`](https://github.com/localheinz/phpstan-rules#functionsnoparameterwithnullabletypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#functionsnoparameterwithnulldefaultvaluerule)
+* [`Localheinz\PHPStan\Rules\Methods\FinalInAbstractClassRule`](https://github.com/localheinz/phpstan-rules#methodsfinalinabstractclassrule)
 * [`Localheinz\PHPStan\Rules\Methods\NoConstructorParameterWithDefaultValueRule`](https://github.com/localheinz/phpstan-rules#methodsnoconstructorparameterwithdefaultvaluerule)
 * [`Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#methodsnonullablereturntypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Methods\NoParameterWithContainerTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#methodsnoparamterwithcontainertypedeclarationrule)
@@ -165,6 +166,10 @@ This rule reports an error when a function has a parameter with a nullable type 
 This rule reports an error when a function has a parameter with `null` as default value.
 
 ### Methods
+
+#### `Methods\FinalInAbstractClassRule`
+
+This rule reports an error when a concrete `public` or `protected `method in an `abstract` class is not `final`.
 
 #### `Methods\NoConstructorParameterWithDefaultValueRule`
 

--- a/rules.neon
+++ b/rules.neon
@@ -23,6 +23,7 @@ rules:
 	- Localheinz\PHPStan\Rules\Functions\NoNullableReturnTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Functions\NoParameterWithNullableTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Functions\NoParameterWithNullDefaultValueRule
+	- Localheinz\PHPStan\Rules\Methods\FinalInAbstractClassRule
 	- Localheinz\PHPStan\Rules\Methods\NoConstructorParameterWithDefaultValueRule
 	- Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule

--- a/src/Methods/FinalInAbstractClassRule.php
+++ b/src/Methods/FinalInAbstractClassRule.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Methods;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+
+final class FinalInAbstractClassRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Stmt\ClassMethod::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node instanceof Node\Stmt\ClassMethod) {
+            throw new ShouldNotHappenException(\sprintf(
+                'Expected node to be instance of "%s", but got instance of "%s" instead.',
+                Node\Stmt\ClassMethod::class,
+                \get_class($node)
+            ));
+        }
+
+        /** @var Reflection\ClassReflection $containingClass */
+        $containingClass = $scope->getClassReflection();
+
+        if (!$containingClass->isAbstract()) {
+            return [];
+        }
+
+        if ($node->isAbstract()) {
+            return [];
+        }
+
+        if ($node->isFinal()) {
+            return [];
+        }
+
+        if ($node->isPrivate()) {
+            return [];
+        }
+
+        return [
+            \sprintf(
+                'Method %s::%s() is not final, but since the containing class is abstract, it should be.',
+                $containingClass->getName(),
+                $node->name->toString()
+            ),
+        ];
+    }
+}

--- a/test/Fixture/Methods/FinalInAbstractClassRule/Failure/AbstractClassWithProtectedMethod.php
+++ b/test/Fixture/Methods/FinalInAbstractClassRule/Failure/AbstractClassWithProtectedMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\FinalInAbstractClassRule\Failure;
+
+abstract class AbstractClassWithProtectedMethod
+{
+    protected function method(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/FinalInAbstractClassRule/Failure/AbstractClassWithPublicMethod.php
+++ b/test/Fixture/Methods/FinalInAbstractClassRule/Failure/AbstractClassWithPublicMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\FinalInAbstractClassRule\Failure;
+
+abstract class AbstractClassWithPublicMethod
+{
+    public function method(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithAbstractMethod.php
+++ b/test/Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithAbstractMethod.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\FinalInAbstractClassRule\Success;
+
+abstract class AbstractClassWithAbstractMethod
+{
+    abstract public function method(): void;
+}

--- a/test/Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithFinalProtectedMethod.php
+++ b/test/Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithFinalProtectedMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\FinalInAbstractClassRule\Success;
+
+abstract class AbstractClassWithFinalProtectedMethod
+{
+    final protected function method(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithFinalPublicMethod.php
+++ b/test/Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithFinalPublicMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\FinalInAbstractClassRule\Success;
+
+abstract class AbstractClassWithFinalPublicMethod
+{
+    final public function method(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithPrivateMethod.php
+++ b/test/Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithPrivateMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\FinalInAbstractClassRule\Success;
+
+abstract class AbstractClassWithPrivateMethod
+{
+    private function method(): void
+    {
+    }
+}

--- a/test/Integration/AbstractTestCase.php
+++ b/test/Integration/AbstractTestCase.php
@@ -41,7 +41,7 @@ abstract class AbstractTestCase extends RuleTestCase
      * @param string $path
      * @param array  $error
      */
-    public function testAnalysisFails(string $path, array $error): void
+    final public function testAnalysisFails(string $path, array $error): void
     {
         $this->analyse(
             [

--- a/test/Integration/Methods/FinalInAbstractClassRuleTest.php
+++ b/test/Integration/Methods/FinalInAbstractClassRuleTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Integration\Methods;
+
+use Localheinz\PHPStan\Rules\Methods\FinalInAbstractClassRule;
+use Localheinz\PHPStan\Rules\Test\Fixture;
+use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use PHPStan\Rules\Rule;
+
+/**
+ * @internal
+ *
+ * @covers \Localheinz\PHPStan\Rules\Methods\FinalInAbstractClassRule
+ */
+final class FinalInAbstractClassRuleTest extends AbstractTestCase
+{
+    public function providerAnalysisSucceeds(): iterable
+    {
+        $paths = [
+            'abstract-class-with-abstract-method' => __DIR__ . '/../../Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithAbstractMethod.php',
+            'abstract-class-with-final-protected-method' => __DIR__ . '/../../Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithFinalProtectedMethod.php',
+            'abstract-class-with-final-public-method' => __DIR__ . '/../../Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithFinalPublicMethod.php',
+            'abstract-class-with-private-method' => __DIR__ . '/../../Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithPrivateMethod.php',
+        ];
+
+        foreach ($paths as $description => $path) {
+            yield $description => [
+                $path,
+            ];
+        }
+    }
+
+    public function providerAnalysisFails(): iterable
+    {
+        $paths = [
+            'abstract-class-with-protected-method' => [
+                __DIR__ . '/../../Fixture/Methods/FinalInAbstractClassRule/Failure/AbstractClassWithProtectedMethod.php',
+                [
+                    \sprintf(
+                        'Method %s::method() is not final, but since the containing class is abstract, it should be.',
+                        Fixture\Methods\FinalInAbstractClassRule\Failure\AbstractClassWithProtectedMethod::class
+                    ),
+                    9,
+                ],
+            ],
+            'abstract-class-with-public-method' => [
+                __DIR__ . '/../../Fixture/Methods/FinalInAbstractClassRule/Failure/AbstractClassWithPublicMethod.php',
+                [
+                    \sprintf(
+                        'Method %s::method() is not final, but since the containing class is abstract, it should be.',
+                        Fixture\Methods\FinalInAbstractClassRule\Failure\AbstractClassWithPublicMethod::class
+                    ),
+                    9,
+                ],
+            ],
+        ];
+
+        foreach ($paths as $description => [$path, $error]) {
+            yield $description => [
+                $path,
+                $error,
+            ];
+        }
+    }
+
+    protected function getRule(): Rule
+    {
+        return new FinalInAbstractClassRule();
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements a `Methods\FinalInAbstractClassRule`, which reports an error when a concrete `public` or `protected` method in an `abstract` class is not `final`
* [x] declares a concrete method in an `abstract` class as `final`

Fixes #88.