### PR TITLE
Enhancement: Implement Methods\PrivateInFinalClassRule

### DIFF
--- a/.php_cs.fixture
+++ b/.php_cs.fixture
@@ -12,6 +12,7 @@ $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71(''), [
     'lowercase_constants' => false,
     'lowercase_keywords' => false,
     'magic_method_casing' => false,
+    'protected_to_private' => false,
     'static_lambda' => false,
 ]);
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`0.12.1...master`](https://github.com/localheinz/phpstan-rules/compare/0.11.0...master).
 
+### Added
+
+* Added `Methods\FinalInAbstractClassRule`, which reports an error when a method in a `final` class is `protected` but could be `private` ([#125](https://github.com/localheinz/phpstan-rules/pull/125)), by [@localheinz](https://github.com/localheinz)
+
 ## [`0.12.1`](https://github.com/localheinz/phpstan-rules/releases/tag/0.12.1)
 
 For a full diff see [`0.12.0...0.12.1`](https://github.com/localheinz/phpstan-rules/compare/0.12.0...0.12.1).

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This package provides the following rules for use with [`phpstan/phpstan`](https
 * [`Localheinz\PHPStan\Rules\Methods\NoParameterWithContainerTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#methodsnoparamterwithcontainertypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule`](https://github.com/localheinz/phpstan-rules#methodsnoparameterwithnullabletypedeclarationrule)
 * [`Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule`](https://github.com/localheinz/phpstan-rules#methodsnoparameterwithnulldefaultvaluerule)
+* [`Localheinz\PHPStan\Rules\Methods\PrivateInFinalClassRule`](https://github.com/localheinz/phpstan-rules#methodsprivateinfinalclassrule)
 * [`Localheinz\PHPStan\Rules\Statements\NoSwitchRule`](https://github.com/localheinz/phpstan-rules#statementsnoswitchrule)
 
 ### Classes
@@ -232,6 +233,10 @@ This rule reports an error when a method declared in
 * an interface
 
 has a parameter with `null` as default value.
+
+#### `Methods\PrivateInFinalClassRule`
+
+This rule reports an error when a method in a `final` class is `protected` but could be `private`.
 
 ### Statements
 

--- a/rules.neon
+++ b/rules.neon
@@ -28,6 +28,7 @@ rules:
 	- Localheinz\PHPStan\Rules\Methods\NoNullableReturnTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Methods\NoParameterWithNullableTypeDeclarationRule
 	- Localheinz\PHPStan\Rules\Methods\NoParameterWithNullDefaultValueRule
+	- Localheinz\PHPStan\Rules\Methods\PrivateInFinalClassRule
 	- Localheinz\PHPStan\Rules\Statements\NoSwitchRule
 
 services:

--- a/src/Methods/PrivateInFinalClassRule.php
+++ b/src/Methods/PrivateInFinalClassRule.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Methods;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+
+final class PrivateInFinalClassRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Stmt\ClassMethod::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node instanceof Node\Stmt\ClassMethod) {
+            throw new ShouldNotHappenException(\sprintf(
+                'Expected node to be instance of "%s", but got instance of "%s" instead.',
+                Node\Stmt\ClassMethod::class,
+                \get_class($node)
+            ));
+        }
+
+        /** @var Reflection\ClassReflection $containingClass */
+        $containingClass = $scope->getClassReflection();
+
+        if (!$containingClass->isFinal()) {
+            return [];
+        }
+
+        if ($node->isPublic()) {
+            return [];
+        }
+
+        if ($node->isPrivate()) {
+            return [];
+        }
+
+        $methodName = $node->name->toString();
+
+        $parentClass = $containingClass->getNativeReflection()->getParentClass();
+
+        if ($parentClass instanceof \ReflectionClass && $parentClass->hasMethod($methodName)) {
+            $parentMethod = $parentClass->getMethod($methodName);
+
+            if ($parentMethod->isProtected()) {
+                return [];
+            }
+        }
+
+        return [
+            \sprintf(
+                'Method %s::%s() is protected, but since the containing class is final, it can be private.',
+                $containingClass->getName(),
+                $methodName
+            ),
+        ];
+    }
+}

--- a/test/Fixture/Methods/PrivateInFinalClassRule/Failure/AnonymousClassWithProtectedMethod.php
+++ b/test/Fixture/Methods/PrivateInFinalClassRule/Failure/AnonymousClassWithProtectedMethod.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Failure;
+
+new class() {
+    protected function method(): void
+    {
+    }
+};

--- a/test/Fixture/Methods/PrivateInFinalClassRule/Failure/FinalClassWithProtectedMethod.php
+++ b/test/Fixture/Methods/PrivateInFinalClassRule/Failure/FinalClassWithProtectedMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Failure;
+
+final class FinalClassWithProtectedMethod
+{
+    protected function method(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/PrivateInFinalClassRule/Success/AbstractClassExtendingAbstractClassWithProtectedMethod.php
+++ b/test/Fixture/Methods/PrivateInFinalClassRule/Success/AbstractClassExtendingAbstractClassWithProtectedMethod.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Success;
+
+abstract class AbstractClassExtendingAbstractClassWithProtectedMethod extends AbstractClassWithProtectedMethod
+{
+}

--- a/test/Fixture/Methods/PrivateInFinalClassRule/Success/AbstractClassWithProtectedMethod.php
+++ b/test/Fixture/Methods/PrivateInFinalClassRule/Success/AbstractClassWithProtectedMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Success;
+
+abstract class AbstractClassWithProtectedMethod
+{
+    protected function method(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/PrivateInFinalClassRule/Success/ClassWithProtectedMethod.php
+++ b/test/Fixture/Methods/PrivateInFinalClassRule/Success/ClassWithProtectedMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Success;
+
+class ClassWithProtectedMethod
+{
+    protected function method(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithPrivateMethod.php
+++ b/test/Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithPrivateMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Success;
+
+final class FinalClassWithPrivateMethod
+{
+    private function method(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithProtectedMethodExtendingClassExtendingClassWithSameProtectedMethod.php
+++ b/test/Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithProtectedMethodExtendingClassExtendingClassWithSameProtectedMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Success;
+
+final class FinalClassWithProtectedMethodExtendingClassExtendingClassWithSameProtectedMethod extends AbstractClassExtendingAbstractClassWithProtectedMethod
+{
+    protected function method(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithProtectedMethodExtendingClassWithSameProtectedMethod.php
+++ b/test/Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithProtectedMethodExtendingClassWithSameProtectedMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Success;
+
+final class FinalClassWithProtectedMethodExtendingClassWithSameProtectedMethod extends AbstractClassWithProtectedMethod
+{
+    protected function method(): void
+    {
+    }
+}

--- a/test/Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithPublicMethod.php
+++ b/test/Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithPublicMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\PrivateInFinalClassRule\Success;
+
+final class FinalClassWithPublicMethod
+{
+    public function method(): void
+    {
+    }
+}

--- a/test/Integration/Methods/PrivateInFinalClassRuleTest.php
+++ b/test/Integration/Methods/PrivateInFinalClassRuleTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @see https://github.com/localheinz/phpstan-rules
+ */
+
+namespace Localheinz\PHPStan\Rules\Test\Integration\Methods;
+
+use Localheinz\PHPStan\Rules\Methods\PrivateInFinalClassRule;
+use Localheinz\PHPStan\Rules\Test\Fixture;
+use Localheinz\PHPStan\Rules\Test\Integration\AbstractTestCase;
+use PHPStan\Rules\Rule;
+
+/**
+ * @internal
+ *
+ * @covers \Localheinz\PHPStan\Rules\Methods\PrivateInFinalClassRule
+ */
+final class PrivateInFinalClassRuleTest extends AbstractTestCase
+{
+    public function providerAnalysisSucceeds(): iterable
+    {
+        $paths = [
+            'final-class-with-private-method' => __DIR__ . '/../../Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithPrivateMethod.php',
+            'final-class-with-public-method' => __DIR__ . '/../../Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithPublicMethod.php',
+            'final-class-with-protected-method-extending-class-with-same-protected-method' => __DIR__ . '/../../Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithProtectedMethodExtendingClassWithSameProtectedMethod.php',
+            'final-class-with-protected-method-extending-class-extending-class-with-same-protected-method' => __DIR__ . '/../../Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithProtectedMethodExtendingClassExtendingClassWithSameProtectedMethod.php',
+            'class-with-protected-method' => __DIR__ . '/../../Fixture/Methods/PrivateInFinalClassRule/Success/ClassWithProtectedMethod.php',
+            'abstract-class-with-protected-method' => __DIR__ . '/../../Fixture/Methods/PrivateInFinalClassRule/Success/AbstractClassWithProtectedMethod.php',
+        ];
+
+        foreach ($paths as $description => $path) {
+            yield $description => [
+                $path,
+            ];
+        }
+    }
+
+    public function providerAnalysisFails(): iterable
+    {
+        $paths = [
+            'final-class-with-protected-method' => [
+                __DIR__ . '/../../Fixture/Methods/PrivateInFinalClassRule/Failure/FinalClassWithProtectedMethod.php',
+                [
+                    \sprintf(
+                        'Method %s::method() is protected, but since the containing class is final, it can be private.',
+                        Fixture\Methods\PrivateInFinalClassRule\Failure\FinalClassWithProtectedMethod::class
+                    ),
+                    9,
+                ],
+            ],
+        ];
+
+        foreach ($paths as $description => [$path, $error]) {
+            yield $description => [
+                $path,
+                $error,
+            ];
+        }
+    }
+
+    protected function getRule(): Rule
+    {
+        return new PrivateInFinalClassRule();
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements a `Methods\PrivateInFinalClassRule` which reports an error when a method in a `final` class is `protected` when it could be `private