### PR TITLE
Fix: Resolve class name before attempting to analyze it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.12.0...master`](https://github.com/localheinz/phpstan-rules/compare/0.12.0...master).
+For a full diff see [`0.12.1...master`](https://github.com/localheinz/phpstan-rules/compare/0.11.0...master).
+
+## [`0.12.1`](https://github.com/localheinz/phpstan-rules/releases/tag/0.12.1)
+
+For a full diff see [`0.12.0...0.12.1`](https://github.com/localheinz/phpstan-rules/compare/0.12.0...0.12.1).
+
+### Fixed
+
+* Started resolving class name in type declaration before attempting to analyze it in the `Methods\NoParameterWithContainerTypeDeclarationRule` to avoid errors where class `self` is not found ([#128](https://github.com/localheinz/phpstan-rules/pull/128)), by [@localheinz](https://github.com/localheinz)
 
 ## [`0.12.0`](https://github.com/localheinz/phpstan-rules/releases/tag/0.12.0)
 

--- a/src/Methods/NoParameterWithContainerTypeDeclarationRule.php
+++ b/src/Methods/NoParameterWithContainerTypeDeclarationRule.php
@@ -73,7 +73,7 @@ final class NoParameterWithContainerTypeDeclarationRule implements Rule
 
         return \array_reduce(
             $node->params,
-            function (array $errors, Node\Param $node) use ($containingClass, $methodName) {
+            function (array $errors, Node\Param $node) use ($scope, $containingClass, $methodName) {
                 $type = $node->type;
 
                 if (!$type instanceof Node\Name) {
@@ -86,7 +86,7 @@ final class NoParameterWithContainerTypeDeclarationRule implements Rule
                 /** @var string $parameterName */
                 $parameterName = $variable->name;
 
-                $classUsedInTypeDeclaration = $this->broker->getClass($type->toCodeString());
+                $classUsedInTypeDeclaration = $this->broker->getClass($scope->resolveName($type));
 
                 if ($classUsedInTypeDeclaration->isInterface()) {
                     foreach ($this->interfacesImplementedByContainers as $interfaceImplementedByContainer) {

--- a/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/ClassImplementingContainerInterfaceWithMethodWithParameterWithSelfAsTypeDeclaration.php
+++ b/test/Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/ClassImplementingContainerInterfaceWithMethodWithParameterWithSelfAsTypeDeclaration.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure;
+
+use Psr\Container;
+
+final class ClassImplementingContainerInterfaceWithMethodWithParameterWithSelfAsTypeDeclaration implements Container\ContainerInterface
+{
+    public function method(self $container): void
+    {
+    }
+
+    public function get($id): void
+    {
+    }
+
+    public function has($id): void
+    {
+    }
+}

--- a/test/Integration/Methods/NoParameterWithContainerTypeDeclarationRuleTest.php
+++ b/test/Integration/Methods/NoParameterWithContainerTypeDeclarationRuleTest.php
@@ -88,6 +88,17 @@ final class NoParameterWithContainerTypeDeclarationRuleTest extends AbstractTest
                     11,
                 ],
             ],
+            'class-implementing-container-interface-with-method-with-parameter-with-self-as-type-declaration' => [
+                __DIR__ . '/../../Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/ClassImplementingContainerInterfaceWithMethodWithParameterWithSelfAsTypeDeclaration.php',
+                [
+                    \sprintf(
+                        'Method %s::method() has a parameter $container with a type declaration of %s, but containers should not be injected.',
+                        Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure\ClassImplementingContainerInterfaceWithMethodWithParameterWithSelfAsTypeDeclaration::class,
+                        Fixture\Methods\NoParameterWithContainerTypeDeclarationRule\Failure\ClassImplementingContainerInterfaceWithMethodWithParameterWithSelfAsTypeDeclaration::class
+                    ),
+                    11,
+                ],
+            ],
             'class-with-method-with-parameter-with-class-implementing-container-interface-as-type-declaration' => [
                 __DIR__ . '/../../Fixture/Methods/NoParameterWithContainerTypeDeclarationRule/Failure/ClassWithMethodWithParameterWithClassImplementingContainerInterfaceAsTypeDeclaration.php',
                 [


### PR DESCRIPTION
This PR

* [x] asserts that `self` as type declaration is resolved properly before attempting to analyze it in the `Methods\NoParameterWithContainerTypeDeclarationRule`
* [x] resolves the class name of the type declaration before attempting to analyze it

Follows #122 and https://github.com/phpstan/phpstan/issues/2430#issuecomment-531470927.