### PR TITLE
Fix: Exclude zendframework/zend-servicemanager from automatic updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -13,6 +13,8 @@ update_configs:
           dependency_name: "nikic/php-parser"
       - match:
           dependency_name: "phpstan/phpstan"
+      - match:
+          dependency_name: "zendframework/zend-servicemanager"
     package_manager: "php:composer"
     update_schedule: "live"
     version_requirement_updates: "increase_versions"


### PR DESCRIPTION
This PR

* [x] excludes `zendframework/zend-servicemanager` from automatic updates

Follows #122.
Related to #129.