### PR TITLE
Fix: Exclude interfaces from analysis by Methods\FinalInAbstractClassRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.12.1...master`](https://github.com/localheinz/phpstan-rules/compare/0.11.0...master).
+For a full diff see [`0.12.2...master`](https://github.com/localheinz/phpstan-rules/compare/0.12.2...master).
+
+## [`0.12.2`](https://github.com/localheinz/phpstan-rules/releases/tag/0.12.2)
+
+For a full diff see [`0.12.0...0.12.1`](https://github.com/localheinz/phpstan-rules/compare/0.12.1...0.12.2).
+
+### Fixed
+
+* Started ignoring interfaces from analysis by `Methods\FinalInAbstractClassRule` to avoid inappropriate errors ([#132](https://github.com/localheinz/phpstan-rules/pull/132)), by [@localheinz](https://github.com/localheinz)
 
 ## [`0.12.1`](https://github.com/localheinz/phpstan-rules/releases/tag/0.12.1)
 

--- a/src/Methods/FinalInAbstractClassRule.php
+++ b/src/Methods/FinalInAbstractClassRule.php
@@ -43,6 +43,10 @@ final class FinalInAbstractClassRule implements Rule
             return [];
         }
 
+        if ($containingClass->isInterface()) {
+            return [];
+        }
+
         if ($node->isAbstract()) {
             return [];
         }

--- a/test/Fixture/Methods/FinalInAbstractClassRule/Success/InterfaceWithPublicMethod.php
+++ b/test/Fixture/Methods/FinalInAbstractClassRule/Success/InterfaceWithPublicMethod.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Localheinz\PHPStan\Rules\Test\Fixture\Methods\FinalInAbstractClassRule\Success;
+
+interface InterfaceWithPublicMethod
+{
+    public function method(): void;
+}

--- a/test/Integration/Methods/FinalInAbstractClassRuleTest.php
+++ b/test/Integration/Methods/FinalInAbstractClassRuleTest.php
@@ -32,6 +32,7 @@ final class FinalInAbstractClassRuleTest extends AbstractTestCase
             'abstract-class-with-final-protected-method' => __DIR__ . '/../../Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithFinalProtectedMethod.php',
             'abstract-class-with-final-public-method' => __DIR__ . '/../../Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithFinalPublicMethod.php',
             'abstract-class-with-private-method' => __DIR__ . '/../../Fixture/Methods/FinalInAbstractClassRule/Success/AbstractClassWithPrivateMethod.php',
+            'interface-with-public-method' => __DIR__ . '/../../Fixture/Methods/FinalInAbstractClassRule/Success/InterfaceWithPublicMethod.php',
         ];
 
         foreach ($paths as $description => $path) {


### PR DESCRIPTION
This PR

* [x] asserts that an error is not reported by the `Methods\FinalInAbstractClassRule` for a `public` method in an interface
* [x] excludes interfaces from analysis by the `Methods\FinalInAbstractClassRule`

Follows #123.
Fixes #131.