### PR TITLE
Fix: Keep cases sorted by key

### DIFF
--- a/test/Integration/Classes/FinalRuleWithExcludedClassNamesTest.php
+++ b/test/Integration/Classes/FinalRuleWithExcludedClassNamesTest.php
@@ -28,9 +28,9 @@ final class FinalRuleWithExcludedClassNamesTest extends AbstractTestCase
     public function providerAnalysisSucceeds(): iterable
     {
         $paths = [
+            'class-neither-abstract-nor-final-but-whitelisted' => __DIR__ . '/../../Fixture/Classes/FinalRuleWithExcludedClassNames/Success/NeitherAbstractNorFinalClassButWhitelisted.php',
             'final-class' => __DIR__ . '/../../Fixture/Classes/FinalRuleWithExcludedClassNames/Success/FinalClass.php',
             'final-class-with-anonymous-class' => __DIR__ . '/../../Fixture/Classes/FinalRuleWithExcludedClassNames/Success/FinalClassWithAnonymousClass.php',
-            'class-neither-abstract-nor-final-but-whitelisted' => __DIR__ . '/../../Fixture/Classes/FinalRuleWithExcludedClassNames/Success/NeitherAbstractNorFinalClassButWhitelisted.php',
             'interface' => __DIR__ . '/../../Fixture/Classes/FinalRuleWithExcludedClassNames/Success/ExampleInterface.php',
             'script-with-anonymous-class' => __DIR__ . '/../../Fixture/Classes/FinalRuleWithExcludedClassNames/Success/anonymous-class.php',
             'trait' => __DIR__ . '/../../Fixture/Classes/FinalRuleWithExcludedClassNames/Success/ExampleTrait.php',

--- a/test/Integration/Methods/PrivateInFinalClassRuleTest.php
+++ b/test/Integration/Methods/PrivateInFinalClassRuleTest.php
@@ -28,12 +28,12 @@ final class PrivateInFinalClassRuleTest extends AbstractTestCase
     public function providerAnalysisSucceeds(): iterable
     {
         $paths = [
-            'final-class-with-private-method' => __DIR__ . '/../../Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithPrivateMethod.php',
-            'final-class-with-public-method' => __DIR__ . '/../../Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithPublicMethod.php',
-            'final-class-with-protected-method-extending-class-with-same-protected-method' => __DIR__ . '/../../Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithProtectedMethodExtendingClassWithSameProtectedMethod.php',
-            'final-class-with-protected-method-extending-class-extending-class-with-same-protected-method' => __DIR__ . '/../../Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithProtectedMethodExtendingClassExtendingClassWithSameProtectedMethod.php',
-            'class-with-protected-method' => __DIR__ . '/../../Fixture/Methods/PrivateInFinalClassRule/Success/ClassWithProtectedMethod.php',
             'abstract-class-with-protected-method' => __DIR__ . '/../../Fixture/Methods/PrivateInFinalClassRule/Success/AbstractClassWithProtectedMethod.php',
+            'class-with-protected-method' => __DIR__ . '/../../Fixture/Methods/PrivateInFinalClassRule/Success/ClassWithProtectedMethod.php',
+            'final-class-with-private-method' => __DIR__ . '/../../Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithPrivateMethod.php',
+            'final-class-with-protected-method-extending-class-extending-class-with-same-protected-method' => __DIR__ . '/../../Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithProtectedMethodExtendingClassExtendingClassWithSameProtectedMethod.php',
+            'final-class-with-protected-method-extending-class-with-same-protected-method' => __DIR__ . '/../../Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithProtectedMethodExtendingClassWithSameProtectedMethod.php',
+            'final-class-with-public-method' => __DIR__ . '/../../Fixture/Methods/PrivateInFinalClassRule/Success/FinalClassWithPublicMethod.php',
         ];
 
         foreach ($paths as $description => $path) {

--- a/test/Integration/Statements/NoSwitchRuleTest.php
+++ b/test/Integration/Statements/NoSwitchRuleTest.php
@@ -47,7 +47,7 @@ final class NoSwitchRuleTest extends AbstractTestCase
                     7,
                 ],
             ],
-            'isset-used-with-incorrect-case' => [
+            'switch-used-with-incorrect-case' => [
                 __DIR__ . '/../../Fixture/Statements/NoSwitchRule/Failure/switch-used-with-incorrect-case.php',
                 [
                     'Control structures using switch should not be used.',


### PR DESCRIPTION
This PR

* [x] keeps cases sorted by key