### PR TITLE
Fix: Stop waiting for builds for PHP 7.1 to complete

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -12,9 +12,6 @@ branches:
         contexts:
           - "Coding Standards"
           - "Static Code Analysis"
-          - "Tests (php7.1, lowest)"
-          - "Tests (php7.1, locked)"
-          - "Tests (php7.1, highest)"
           - "Tests (php7.2, lowest)"
           - "Tests (php7.2, locked)"
           - "Tests (php7.2, highest)"


### PR DESCRIPTION
This PR

* [x] stops waiting for builds for PHP 7.1 to complete

Follows #141.
