### PR TITLE
Fix: Run php-cs-fixer for fixtures

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -43,6 +43,9 @@ jobs:
       - name: "Run friendsofphp/php-cs-fixer"
         run: php7.2 vendor/bin/php-cs-fixer fix --config=.php_cs --diff --diff-format=udiff --dry-run --using-cache=no --verbose
 
+      - name: "Run friendsofphp/php-cs-fixer for fixtures"
+        run: php7.2 vendor/bin/php-cs-fixer fix --config=.php_cs.fixture --diff --diff-format=udiff --dry-run --using-cache=no --verbose
+
   static-code-analysis:
     name: "Static Code Analysis"
 

--- a/.php_cs.fixture
+++ b/.php_cs.fixture
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Ergebnis\PhpCsFixer\Config;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71(''), [
+    'constant_case' => false,
     'declare_strict_types' => false,
     'error_suppression' => false,
     'final_class' => false,

--- a/.php_cs.fixture
+++ b/.php_cs.fixture
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Localheinz\PhpCsFixer\Config;
+use Ergebnis\PhpCsFixer\Config;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71(''), [
     'declare_strict_types' => false,

--- a/.php_cs.fixture
+++ b/.php_cs.fixture
@@ -8,6 +8,7 @@ $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71(''), [
     'declare_strict_types' => false,
     'error_suppression' => false,
     'final_class' => false,
+    'final_public_method_for_abstract_class' => false,
     'header_comment' => false,
     'lowercase_constants' => false,
     'lowercase_keywords' => false,


### PR DESCRIPTION
This PR

* [x] runs `php-cs-fixer` for fixtures on GitHub actions as well
* [x] fixes an import following #145
* [x] disables the `final_public_method_for_abstract_class` fixer for fixtures
* [x] disables the `constant_case` fixer for fixtures