### PR TITLE
Enhancement: Run builds on PHP 7.4

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -11,16 +11,19 @@ branches:
       required_status_checks:
         contexts:
           - "Coding Standards (7.2)"
-          - "Dependency Analysis (7.3)"
-          - "Static Code Analysis (7.3)"
+          - "Dependency Analysis (7.4)"
+          - "Static Code Analysis (7.4)"
           - "Tests (7.2, lowest)"
           - "Tests (7.2, locked)"
           - "Tests (7.2, highest)"
           - "Tests (7.3, lowest)"
           - "Tests (7.3, locked)"
           - "Tests (7.3, highest)"
-          - "Code Coverage (7.3)"
-          - "Mutation Tests (7.3)"
+          - "Tests (7.4, lowest)"
+          - "Tests (7.4, locked)"
+          - "Tests (7.4, highest)"
+          - "Code Coverage (7.4)"
+          - "Mutation Tests (7.4)"
           - "codecov/patch"
           - "codecov/project"
         strict: false

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.3
+          - 7.4
 
     steps:
       - name: "Checkout"
@@ -109,7 +109,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.3
+          - 7.4
 
     steps:
       - name: "Checkout"
@@ -146,6 +146,7 @@ jobs:
         php-version:
           - 7.2
           - 7.3
+          - 7.4
 
         dependencies:
           - lowest
@@ -200,7 +201,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.3
+          - 7.4
 
     steps:
       - name: "Checkout"
@@ -240,7 +241,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.3
+          - 7.4
 
     steps:
       - name: "Checkout"

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "ergebnis/test-util": "~0.9.0",
     "infection/infection": "~0.13.6",
     "localheinz/composer-normalize": "^1.3.1",
+    "nette/di": "^3.0.1",
     "phpstan/phpstan-deprecation-rules": "~0.11.2",
     "phpstan/phpstan-strict-rules": "~0.11.1",
     "phpunit/phpunit": "^8.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "718b2beb3d79506ddc67ce3bd277191c",
+    "content-hash": "86cf242d470402407a67acd1f36005f9",
     "packages": [
         {
             "name": "composer/xdebug-handler",
@@ -2300,6 +2300,7 @@
                 "json",
                 "printer"
             ],
+            "abandoned": "ergebnis/json-printer",
             "time": "2018-08-11T23:54:50+00:00"
         },
         {


### PR DESCRIPTION
This PR

* [x] runs builds on PHP 7.4
* [x] requires `nette/di:^3.0.1`